### PR TITLE
Add simple link styling for buttons

### DIFF
--- a/scss/elements/_buttons.scss
+++ b/scss/elements/_buttons.scss
@@ -104,6 +104,18 @@ button {
         }
     }
 
+    &--link {
+        background: transparent;
+        color: $matisse;
+        padding: 6px 0 2px 0;
+
+        &:hover,
+        &:focus {
+            text-decoration: underline;
+            outline: 0;
+        }
+    }
+
     &--small {
         font-size: 12px;
         height: 32px;


### PR DESCRIPTION
### What

Add a class for buttons to make them have the same styling (including hover/focus) as a link. Currently only being used on DD 'help with file types' show/hide.

### How to review

A button looks exactly like an ordinary anchor.

### Who can review

@jondewijones 
