### PR TITLE
Add styling to unavailable chart in markdown

### DIFF
--- a/scss/elements/_sections.scss
+++ b/scss/elements/_sections.scss
@@ -58,6 +58,23 @@ section {
 				padding-left: $col;
 				margin-bottom: ($baseline * 4);
 
+				&--error {
+					height: ($baseline * 36);
+					font-size: 17px;
+					font-weight: 600;
+					position: relative;
+					text-align: center;
+				}
+
+				&--error__message {
+					position: absolute;
+					top: ($baseline * 16);
+					left: 0;
+					width: 100%;
+					text-align: center;
+					padding: 5px 0 3px 0;
+				}
+
 				.markdown-chart, .markdown-table-wrap {
 					//Charts take up extra space when available (ie on desktop/tablet)
 					width: 700px;

--- a/scss/old-ie.scss
+++ b/scss/old-ie.scss
@@ -20,6 +20,7 @@ $old-ie: true;
 @import "utilities/widths";
 @import "utilities/background-colour";
 @import "utilities/font-size";
+@import "utilities/fonts";
 
 
 @import "elements/type";


### PR DESCRIPTION
### What

Added 'error' modifier to markdown chart containers so that unavailable charts had specific styling. Also updated old-ie SCSS file to include latest components that were missing.

### How to review

Add a new chart in Florence, then delete it from the list of charts but not from the markdown. You should get shown a 'Chart unavailable' in it's original space on babbage now.

### Who can review

@jondewijones or @CarlHembrough 
