### PR TITLE
make port configurable from env

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "postinstall": "npm run build",
         "watch-css": "./node_modules/onchange/cli.js 'scss' -- npm run build-css",
         "watch-js": "./node_modules/catw/bin/cmd.js -v $npm_package_config_js -o dist/js/main.js",
-        "server": "http-server -p 9000 --cors",
+        "server": "http-server -p ${PORT:-9000} --cors",
         "dev": "npm run watch-css & npm run watch-js & npm run server"
     },
     "repository": {


### PR DESCRIPTION
Make port configurable from environment

To test:
- run `./run.sh`, should start on port 9000
- run `PORT=10000 ./run.sh`, should start on port 10000