### PR TITLE
Remove having alignment on table elements

### DIFF
--- a/scss/elements/_tables-and-data.scss
+++ b/scss/elements/_tables-and-data.scss
@@ -16,20 +16,11 @@ table {
 
     th {
         padding: 7px 0 1px 0;
-        text-align:right;
 
         // Not needed on ons.gov.uk because table builder carries through borders - uncomment if other users of this library need it
         //&[scope="col"] {
         //    border-bottom: 1px solid $thunder;
         //}
-
-        &.left{
-            text-align:left;
-        }
-    }
-
-    tr th:first-child{
-        text-align:left;  
     }
 
     td {


### PR DESCRIPTION
### What

Markdown table alignment was being overwritten by default alignment on table elements. The default alignment was added during [an earlier commit](https://github.com/ONSdigital/sixteens/commit/ad0dc575142b2e024da223ca2f3dfad7a6c38fe9) and we're not sure why, so have removed it until we can see an obvious need for it.

### How to review

No alignment is on table headings or table data elements.

### Who can review

Jon Jones
