### PR TITLE
Hide date picker container on IE8

### DIFF
--- a/scss/components/_date-picker.scss
+++ b/scss/components/_date-picker.scss
@@ -7,6 +7,10 @@
     width: ($col * 16);
     z-index: 10; // Otherwise elements on mobile go over the top
 
+    @if $old-ie == true {
+        display: none;
+    }
+
     &:before {
         width: 0;
         height: 0;


### PR DESCRIPTION
### What

Empty date picker container was showing on IE8 even though it is not JS enhanced, so shouldn't be showing at all.

### How to review

Set date picker container to hide on IE8. Simple code review should do fine.

### Who can review

Anyone but me.
