### PR TITLE
Added styles for the filter overview components

### DIFF
--- a/scss/components/_filter-selection.scss
+++ b/scss/components/_filter-selection.scss
@@ -1,0 +1,41 @@
+// Filter Selection (Shopping basket)
+
+.filter-selection {
+  &__header {
+    background: $gallery;
+    padding:15px;
+
+    h2 {
+      font-size: 20px;
+      margin: 0;
+      padding:0;
+      display: inline-block;
+    }
+    a {
+      float:right;
+      text-align: right;
+    }
+  }
+
+  ul {
+    border-left: 1px solid $gallery;
+    border-right: 1px solid $gallery;
+    margin: 0;
+    li {
+      border-bottom: 1px solid $gallery;
+      padding: 15px;
+      margin: 0;
+      overflow: hidden;
+      span {
+        float: left;
+      }
+      @include breakpoint(md) {
+        span.remove-link {
+          float:right;
+          text-align: right;
+          padding-left: 10px;
+        }
+      }
+    }
+  }
+}

--- a/scss/elements/_buttons.scss
+++ b/scss/elements/_buttons.scss
@@ -103,7 +103,12 @@ button {
             cursor: default;
         }
     }
-
+    &--focus {
+      &:focus {
+          @include box-shadow(0 0 0 5px $carrot);
+          outline: 0;
+      }
+    }
     &--link {
         background: transparent;
         color: $matisse;
@@ -115,8 +120,8 @@ button {
         }
 
         &:focus {
-            @include box-shadow(0 0 0 5px $carrot);  
-            outline: 0;      
+            @include box-shadow(0 0 0 5px $carrot);
+            outline: 0;
         }
 
         &-disabled {

--- a/scss/elements/_inputs-and-labels.scss
+++ b/scss/elements/_inputs-and-labels.scss
@@ -104,47 +104,23 @@ input, select {
     border: 1px solid $iron;
 }
 
-.select-alt{
-	position: relative;
-	display: inline-block;
-	&:before {
-		content:'';
-		position: absolute;
-		right:10px;
-		top:25%;
-		width: 0;
-		height: 0;
-		border: 0 solid transparent;
-		border-right-width: 5px;
-		border-left-width: 5px;
-		border-bottom: 7px solid $thunder;
-	}
-	&:after {
-		content:'';
-		position: absolute;
-		right:10px;
-		bottom:25%;
-		width: 0;
-		height: 0;
-		border: 0 solid transparent;
-		border-right-width: 5px;
-		border-left-width: 5px;
-		border-top: 7px solid $thunder;
-	}
-	.select {
-		font-size: 16px;
+@if $old-ie != true {
+	.select-alt{
+		position: relative;
+		display: inline-block;
 		border: 2px solid $thunder;
-		padding: 5px 30px 5px 10px;
-		@include border-radius(0);
-		-webkit-appearance:none;
-		-moz-appearance:none;
-		appearance:none;
-		&:focus {
-				outline: 3px solid $carrot;
+		.select {
+			font-size: 16px;
+			border: none;
+			@include border-radius(0);
+			padding: 5px;
+			outline:none;
+			&:focus {
+					outline: 3px solid $carrot;
+			}
 		}
 	}
 }
-
 .width-auto {
     width: auto !important;
 }

--- a/scss/elements/_inputs-and-labels.scss
+++ b/scss/elements/_inputs-and-labels.scss
@@ -104,8 +104,47 @@ input, select {
     border: 1px solid $iron;
 }
 
+.select-alt{
+	position: relative;
+	display: inline-block;
+	&:before {
+		content:'';
+		position: absolute;
+		right:10px;
+		top:25%;
+		width: 0;
+		height: 0;
+		border: 0 solid transparent;
+		border-right-width: 5px;
+		border-left-width: 5px;
+		border-bottom: 7px solid $thunder;
+	}
+	&:after {
+		content:'';
+		position: absolute;
+		right:10px;
+		bottom:25%;
+		width: 0;
+		height: 0;
+		border: 0 solid transparent;
+		border-right-width: 5px;
+		border-left-width: 5px;
+		border-top: 7px solid $thunder;
+	}
+	.select {
+		font-size: 16px;
+		border: 2px solid $thunder;
+		padding: 5px 30px 5px 10px;
+		@include border-radius(0);
+		-webkit-appearance:none;
+		-moz-appearance:none;
+		appearance:none;
+		&:focus {
+				outline: 3px solid $carrot;
+		}
+	}
+}
+
 .width-auto {
     width: auto !important;
 }
-
-

--- a/scss/elements/_type.scss
+++ b/scss/elements/_type.scss
@@ -120,6 +120,10 @@ a {
     &:focus {
         text-decoration: underline;
     }
+    &:focus {
+      @include box-shadow(0 0 0 5px $carrot);
+      outline: 0;
+    }
 }
 
 address {

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -47,6 +47,7 @@ $old-ie: false;
 @import "components/footer";
 @import "components/accordions";
 @import "components/filters";
+@import "components/filter-selection";
 @import "components/tabs";
 @import "components/search-results";
 @import "components/tooltip";

--- a/scss/old-ie.scss
+++ b/scss/old-ie.scss
@@ -47,6 +47,7 @@ $old-ie: true;
 @import "components/footer";
 @import "components/accordions";
 @import "components/filters";
+@import "components/filter-selection";
 @import "components/tabs";
 @import "components/search-results";
 @import "components/tooltip";

--- a/scss/utilities/_utilities.scss
+++ b/scss/utilities/_utilities.scss
@@ -295,6 +295,11 @@
 	clear: right !important;
 }
 
+// Make an element full width
+.full-width {
+	width:100%!important;
+}
+
 // hiding polyfill placeholder - temporary fix for IE8/9
 
 .placeholder {
@@ -429,6 +434,10 @@
 
 .underline-link {
     text-decoration: underline !important;
+}
+
+.text-wrap {
+	white-space: normal;
 }
 
 // Opacity value with fallback

--- a/scss/utilities/_utilities.scss
+++ b/scss/utilities/_utilities.scss
@@ -570,3 +570,7 @@
         clear: both;
     }
 }
+// Use as alternative to overflow:hidden
+.clearfix {
+    @extend %clearfix;
+}

--- a/scss/utilities/_utilities.scss
+++ b/scss/utilities/_utilities.scss
@@ -548,10 +548,13 @@
            }
        }
    }
-}   
-
+}
 @include body-adjust-util;
 
+// Make all links within the component underlined
+.underline-all-links a:not(.btn) {
+	@extend .underline-link;
+}
 
 // Use as alternative to overflow:hidden
 %clearfix {
@@ -567,4 +570,3 @@
         clear: both;
     }
 }
-


### PR DESCRIPTION
### What

Created the filter overview and age dimension journey using stubbed data.

### How to review

Requires the "**feature/filter-overview**" branches on the following repo's (which also need a code review):

dp-filter-dataset-controller - https://github.com/ONSdigital/dp-frontend-filter-dataset-controller/tree/feature/filter-overview

dp-frontend-models - https://github.com/ONSdigital/dp-frontend-models/tree/feature/filter-overview

dp-frontend-renderer - https://github.com/ONSdigital/dp-frontend-renderer/tree/feature/filter-overview

sixteens - https://github.com/ONSdigital/sixteens/tree/feature/filter-overview

Run the services and check that the page displays and shows dimensions and filters.

Go to http://localhost:20001/jobs/12345/dimensions/

Check the filter overview shows correctly. Click the age dimension filter and check the page (currently non functional). Click the "Add from list" link and check the page displays correctly.

### Who can review

Front end developer.