### PR TITLE
Fixed mobile nav for cmd. Changed focus of links to only occur in cmd…

### DIFF
--- a/scss/components/_breadcrumb.scss
+++ b/scss/components/_breadcrumb.scss
@@ -5,11 +5,10 @@
 	// line-height: 24px;
 	padding: ($baseline * 2) 0 (($baseline * 1) - 1) 0;
 	border-bottom: 1px solid $iron;
-
+	clear:both;
 	@include breakpoint(sm) {
 		padding: $baseline 0 (($baseline * 2) - 1) 0;
 	}
-    
 
 	&__list {
 		list-style: none;

--- a/scss/components/_header.scss
+++ b/scss/components/_header.scss
@@ -328,6 +328,10 @@
         border-right: 1px solid $thunder;
     }
 
+    &__no-search {
+      width:100%;
+    }
+
     &__search {
         background-color: $ship-grey;
         font-size: 17px;

--- a/scss/elements/_type.scss
+++ b/scss/elements/_type.scss
@@ -120,10 +120,6 @@ a {
     &:focus {
         text-decoration: underline;
     }
-    &:focus {
-      @include box-shadow(0 0 0 5px $carrot);
-      outline: 0;
-    }
 }
 
 address {

--- a/scss/utilities/_ellipsis.scss
+++ b/scss/utilities/_ellipsis.scss
@@ -11,23 +11,23 @@
 	&:before {
 		content:"";
 		float: left;
-		width: 5px; 
-		height: $height; 
+		width: 5px;
+		height: $height;
 	}
 
 	& > * {
 		float: right;
 		width: 100%;
-		margin-left: -5px !important; 
-	}		
+		margin-left: -5px !important;
+	}
 
 	&:after {
 		content: "\02026";
-		float: right; 
+		float: right;
 		position: relative;
-		top: -32px; 
-		left: 100%; 
-		width: $ellipsiswidth; 
+		top: -32px;
+		left: 100%;
+		width: $ellipsiswidth;
 		margin-left: -$ellipsiswidth;
 		padding-right: 5px;
 		padding-bottom: 24px;
@@ -35,8 +35,8 @@
 		background: inherit;
 		line-height: 8px;
 		text-indent: $ellipsistextindent;
+		clear:none;
 	}
 
 
 }
-

--- a/scss/utilities/_utilities.scss
+++ b/scss/utilities/_utilities.scss
@@ -601,6 +601,10 @@
 // Make all links within the component underlined
 .underline-all-links a:not(.btn) {
 	@extend .underline-link;
+	&:focus {
+		@include box-shadow(0 0 0 5px $carrot);
+		outline: 0;
+	}
 }
 
 // Use as alternative to overflow:hidden


### PR DESCRIPTION
### What

We are not rendering the global search for the cmd journey. On mobile the search tab was still showing.

We added the new focus style to all clickable elements globally. This created some issues on certain patterns so it's now contained to the cmd journey.

### How to review

Pull  this branch and run. Also requires "feature/mobile-search-bug" on the renderer repo to be running.

View the mobile layout and check that the search tab does not show and the menu looks ok.

Navigate to pages outside the cmd component and check that the focus is as is on live.

### Who can review

Anyone.