### PR TITLE
Prevent checkbox label overflow by fixing width to 400px

### DIFF
--- a/scss/elements/_checkbox.scss
+++ b/scss/elements/_checkbox.scss
@@ -20,6 +20,8 @@
             }
 
             + label {
+                width: 400px;
+
                 &:before {
                     content: "";
                     border: 2px solid $ship-grey;


### PR DESCRIPTION
### What

- Stops overflowing of button next to checkbox

### How to review

- Check the buttons do not overflow on hierarchy selection

Navigate to filter overview page, select goods-and-services. Verify you can navigate through the hierarchy successfully.

Note you will not be able to add or remove filter selections until the dataset api and filter api are available

### Who can review

Anyone