### PR TITLE
Add class to disable button click

### DIFF
--- a/scss/elements/_buttons.scss
+++ b/scss/elements/_buttons.scss
@@ -39,6 +39,10 @@ button {
         }
     }
 
+    &--no-click {
+        pointer-events: none;
+    }
+
     &--secondary {
         background-color: $secondary;
         color: $white;


### PR DESCRIPTION
### What

The real filter api has been hooked into the filter-dataset-controller so you can successfully add/remove dimension options to your filter job

### How to review

Start the following services:

- dp-frontend-router
- dp-frontend-dataset-controller
- dp-frontend-filter-dataset-controller (feature/unstubination)
- dp-frontend-router (feature/unstubination)
- zebedee
- babbage
- sixteens
- dp-hierarchy-api
- dp-codelist-api
- dp-filter-api

Navigate to a dataset landing page. For example:

http://localhost:20000/employmentandlabourmarket/peopleinwork/workplacedisputesandworkingconditions/datasets/labourdisputesbysectorlabd02

Click filter and download. Verify that a filter job has been created.

Click on the time dimension and verify that you can add/remove (including all) dimension options for both the range selector and the list selector. Verify that when you return to the filter options, the number of selected options are visible next to the time dimension.

Please be aware that there is a bug on the filter-api where too many connections are being opened and not closed to the database. If you get an internal error you should restart the filter api until this is fixed.

### Who can review

Anyone

