### PR TITLE
Styles for tweaks to the preview table and filter overview list

### DIFF
--- a/scss/components/_filter-selection.scss
+++ b/scss/components/_filter-selection.scss
@@ -45,4 +45,32 @@
   &__filter {
     @include truncateSingleLine;
   }
+  @include breakpoint(md) {
+    li {
+      &:not(:first-child) {
+        position: relative;
+        &:hover {
+          background: $gallery;
+        }
+        a {
+          position: absolute;
+          width: 100%;
+          height: 100%;
+          right: 0;
+          top:0;
+          text-align: right;
+          padding-top:15px;
+          padding-right:10px;
+        }
+      }
+      div:first-child {
+        padding-left:10px;
+      }
+    }
+  }
+  @include breakpoint(lg) {
+    div:last-child {
+      padding-right:10px;
+    }
+  }
 }

--- a/scss/elements/_tables-and-data.scss
+++ b/scss/elements/_tables-and-data.scss
@@ -179,21 +179,31 @@ dd {
 .table-preview {
   max-width:90%;
   min-width:90%;
-  overflow-x: scroll;
+  overflow: hidden;
+  &:hover {
+    overflow-x: scroll
+  }
   table {
     display: table;
     border-collapse: collapse;
+    width:100%;
     tbody, thead {
       td, th {
-        padding: $col/2 $col $col/2 0;
+        padding: $col/2 $col * 4 $col/2 0;
         vertical-align: baseline;
         font-weight: $base-font-weight;
         text-align: left;
         border-bottom: 1px solid $gallery;
+        min-width: $col * 8;
+      }
+      td {
+        white-space: nowrap;
       }
     }
     thead th{
-      font-size:16px;
+      font-weight: bold;
+      vertical-align: bottom;
+      line-height: 18px;
     }
   }
 }


### PR DESCRIPTION
### What

Preview page: Added some styling for the preview table to allow scrolling based on user feedback.

Filter overview page: Row is now clickable and not just the link.

### How to review

Pull this branch on the renderer: https://github.com/ONSdigital/dp-frontend-renderer/tree/feature/preview-iteration
Run services to allow cmd journey and check the two pages detailed above. 

Services required: compose, filter dataset controller, dataset controller, florence, babbage, renderer, router, sixteens, zebedee, filter-api, code-list api, hierarchy-api.

Check the list is clickable. Check the preview table is scrollable.

### Who can review

Anyone