### PR TITLE
Fix button border radius

### DIFF
--- a/scss/elements/_buttons.scss
+++ b/scss/elements/_buttons.scss
@@ -18,6 +18,7 @@ button {
     transition: background-color 0.25s ease-out;
     text-decoration: none;
     line-height: $base-line-height;
+    border-radius: 0;
 
     &--primary {
         background-color: $primary;


### PR DESCRIPTION
Since Chrome has updated it's been setting a default border-radius on buttons - this updates set the border radius on buttons to 0.