### PR TITLE
Feature/stripped article iteration

### DIFF
--- a/scss/components/_breadcrumb.scss
+++ b/scss/components/_breadcrumb.scss
@@ -63,10 +63,6 @@
 			padding: 10px 0 6px 0;
 		}
 
-		a {
-			text-decoration: underline;
-		}
-
 		&:after {
 			content: '>';
 			padding-left: 8px;

--- a/scss/components/_page.scss
+++ b/scss/components/_page.scss
@@ -86,19 +86,31 @@
 			margin-top: 0;
 			margin-bottom: ($baseline * 1);
 			font-weight: bold;
+			font-size: 38px;
+			line-height: 48px;
+
+			@include breakpoint(sm) {
+				font-size: 32px;
+				line-height: 40px;
+			}
+
+
 		}
 		&__content {
-			font-size: 21px;
+			font-size: 24px;
 			margin-top: ($baseline * 0);
 			margin-bottom: 0;
 			padding: 2px 0 14px 0;
 			line-height: 32px;
 
 			@include breakpoint(sm) {
-				font-size: 17px;
+				font-size: 20px;
 				padding: 9px 0 7px 0;
-				margin-bottom: ($baseline * 4);
 			}
+		}
+
+		&__meta {
+			font-size: 16px;
 		}
 	}
 	&-content {

--- a/scss/components/_tiles.scss
+++ b/scss/components/_tiles.scss
@@ -920,7 +920,7 @@
 	&-content {
 		&__title {
 			font-size: 17px;
-			font-weight: 400;
+			font-weight: 700;
 			line-height: 24px;
 			margin: 16px 0;
 			padding: 5px 0 3px 0;

--- a/scss/elements/_sections.scss
+++ b/scss/elements/_sections.scss
@@ -148,13 +148,65 @@
                     margin-left: 0;
                 }
 
+				p, li {
+					line-height: 32px;
+					font-size: 18px;
+
+					@include breakpoint(sm) {
+						font-size: 16px;
+					}
+
+				}
+
+				ul {
+					padding-left: $col * 1.5; // 24px;
+				}
+
                 h2, h3, h4, h5, h6 {
                     font-weight: 700;
                 }
 
                 h2 {
                     line-height: 32px;
+					font-size: 30px;
+
+					@include breakpoint(sm) {
+						font-size: 24px;
+					}
                 }
+
+				h3 {
+					font-size: 24px;
+
+					@include breakpoint(sm) {
+						font-size: 18px;
+					}
+				}
+
+				h4 {
+					font-size: 20px;
+
+					@include breakpoint(sm) {
+						font-size: 16px;
+					}
+				}
+
+				h5 {
+					font-size: 18px;
+
+					@include breakpoint(sm) {
+						font-size: 14px;
+					}
+				}
+
+				h6 {
+					font-size: 16px;
+
+					@include breakpoint(sm) {
+						font-size: 14px;
+					}
+				}
+
 
             }
             // End of Neutral article specific styling


### PR DESCRIPTION
### What

Various changes (font sizes, line heights, li styling, etc) so that stripped down article matches prototype.

### How to review

Pull babbage branch `feature/stripped-article` and check that changes match [prototype](https://onsdigital.github.io/dp-design-manual/sprint/9/visual-article-iteration/). 

### Who can review

Probably @Crispioso and @benjystanton 
