### PR TITLE
Additional logic to show and hide save button on time selector

### DIFF
--- a/js/app/time-selector.js
+++ b/js/app/time-selector.js
@@ -1,32 +1,31 @@
 $(document).ready(function() {
     removeAllCheck();
+    checkSelections(true);
 
-    if ($(".checkbox__input").length === $(".checkbox__input.checked").length) {
-       if ($(".checkbox__input").length > 19) {
-            $("#add-all-save-and-return").removeClass("js-hidden");
-       }
-    }
+    $("#time-form input[type='radio']").click(function(){
+        if(this.id === "time-selection-list"){
+            checkSelections(true);
+        } else {
+            checkSelections(false);
+        }
+    });
 
     $(".checkbox__input").click(function() {
        removeAllCheck();
-       $("#add-all-save-and-return").addClass("js-hidden");
     })
 
     $("input.add-all").click(function(e) {
         e.preventDefault();
         $(".checkbox__input").prop('checked', true);
         removeAllCheck();
-
-        if ($(".checkbox__input").length > 19) {
-            $("#add-all-save-and-return").removeClass("js-hidden");
-        }
+        checkSelections(true);
     })
 
     $("#remove-all").click(function(e) {
         e.preventDefault();
         $(".checkbox__input").prop('checked', false);
         removeAllCheck();
-        $("#add-all-save-and-return").addClass("js-hidden");
+        checkSelections(false);
     })
 
     var endDateChange = function() {
@@ -201,4 +200,18 @@ function removeAllCheck() {
     } else {
         $("#remove-all").addClass("js-hidden");
     }
+}
+
+function checkSelections(bool) {
+    if (bool === false) {
+        $("#add-all-save-and-return").addClass("js-hidden");
+
+    }
+    if (bool === true) {
+        if ($(".checkbox__input").length > 19 && $(".checkbox__input").length === $(".checkbox__input:checked").length) {
+            $("#add-all-save-and-return").removeClass("js-hidden");
+        }
+    } 
+    
+
 }


### PR DESCRIPTION
### What

Fixed bug where the additional save and return was not being removed upon selection of another time type.

### How to review

**Description** - Save and return button on top right corner of the page should be hidden when a user selects a different option.

**Steps to reproduce**

In CPIH dataset, select Time dimension option, select Add months from list option.
Select Add all link, you can see the Save and return button on top right of the page.
Now, Select different radio option e.g. Add a range of moths

**Expected outcome**

Save and return button should not be shown

### Who can review

Anyone