### PR TITLE
Check for undefined values before attempting to read filter download url

### DIFF
--- a/js/app/preview.js
+++ b/js/app/preview.js
@@ -28,7 +28,10 @@ function getDownloadFiles() {
     success: function(response) {
       var downloads = response.downloads;
       // Check if the response has the file data
-      if (!downloads.xls.href == '' && !downloads.csv.href == '') {
+      if (typeof downloads != "undefined"
+          && typeof downloads.csv != "undefined" && typeof downloads.xls != "undefined"
+          && typeof downloads.xls.href != "undefined" && downloads.xls.href != ''
+          && typeof downloads.csv.href != "undefined" && downloads.csv.href != '') {
         loader.remove();
         $('#other-downloads').removeClass('js-hidden');
         addFilesToPage(response);


### PR DESCRIPTION
A recent change in the filter API means that values can be returned as undefined instead of empty strings. I have updated the code to check for undefined values at every level down to the download href value.