### PR TITLE
Set focus outline to none

### DIFF
--- a/scss/elements/_sections.scss
+++ b/scss/elements/_sections.scss
@@ -29,6 +29,10 @@
 
 		&--markdown {
 
+			&:focus {
+				outline: none;
+			}
+
 			@include breakpoint(sm) {
 				padding: 0;
 			}


### PR DESCRIPTION
### What

Remove focus on content markdown sections

### How to review

Click a table of content link and check selected content is focused, but with no visible feedback (e.g. outline)

### Who can review

Anyone
