### PR TITLE
Fix sticky table of contents focus

### DIFF
--- a/js/app/table-of-contents.js
+++ b/js/app/table-of-contents.js
@@ -89,7 +89,7 @@ $(function() {
                     }
 
                     $(targetId).attr('tabindex','-1');
-                    $(targetId).focus({preventScroll: true});
+                    $(targetId)[0].focus({preventScroll: true});
                 });
 
                 // Check if GTM dataLayer exists and if it does push


### PR DESCRIPTION
### What

Fix focus not moving down page on section select from sticky table of contents.

We were running a native function on a jQuery object, so I simply used the native element instead to run the `focus()` function on.

### How to review

Go to any publication with a sticky table of contents on it, select a section from the sticky table of contents.

The page should scroll down to the desired section and pressing `tab` should move the focus down the page from the section you've just scrolled to (not from the top of the page).

### Who can review

Ric
