### PR TITLE
Added new focus styles to all anchor tags

### DIFF
--- a/scss/elements/_type.scss
+++ b/scss/elements/_type.scss
@@ -1,7 +1,7 @@
 //_type.scss
 
 //--[vars]--
-$base-font-family: 'Open Sans', Helvetica, Arial, sans-serif;
+$base-font-family: "Open Sans", Helvetica, Arial, sans-serif;
 //$base-font-family: Helvetica, sans-serif;
 $base-font-size: 14px;
 $base-line-height: $baseline * 3;
@@ -11,187 +11,187 @@ $base-text-colour: $ship-grey;
 //--[vars end]--
 
 body {
-    font-family: $base-font-family;
-    font-size: $base-font-size;
-    font-weight: $base-font-weight;
-    line-height: $base-line-height;
-    color: $base-text-colour;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
+  font-family: $base-font-family;
+  font-size: $base-font-size;
+  font-weight: $base-font-weight;
+  line-height: $base-line-height;
+  color: $base-text-colour;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 h1 {
-    font-size: 35px;
-    font-weight: $base-font-weight;
-    line-height: 48px;
-    margin: ($baseline * 6) 0;
-    padding: 2px 0 6px 0;
+  font-size: 35px;
+  font-weight: $base-font-weight;
+  line-height: 48px;
+  margin: ($baseline * 6) 0;
+  padding: 2px 0 6px 0;
 
-    // Alternative H1 for census landing page
-    &--census {
-        color: $census;
-        font-weight: 700;
-    }
+  // Alternative H1 for census landing page
+  &--census {
+    color: $census;
+    font-weight: 700;
+  }
 
-    @include breakpoint(sm) {
-        font-size: 29px;
-        line-height: 40px;
-        padding: 0;
-    }
-
+  @include breakpoint(sm) {
+    font-size: 29px;
+    line-height: 40px;
+    padding: 0;
+  }
 }
 
 h2 {
-    font-size: 24px;
-    font-weight: $base-font-weight;
-    line-height: 24px;
-    margin: ($baseline * 5) 0 0 0;
-    padding: 3px 0 5px 0;
+  font-size: 24px;
+  font-weight: $base-font-weight;
+  line-height: 24px;
+  margin: ($baseline * 5) 0 0 0;
+  padding: 3px 0 5px 0;
 
-    @include breakpoint(sm) {
-        font-size: 22px;
-    }
+  @include breakpoint(sm) {
+    font-size: 22px;
+  }
 }
 
 h3 {
-    font-size: 21px;
-    font-weight: $base-font-weight;
-    line-height: 24px;
-    margin: ($baseline * 2) 0 0 0;
-    padding: 3px 0 5px 0;
+  font-size: 21px;
+  font-weight: $base-font-weight;
+  line-height: 24px;
+  margin: ($baseline * 2) 0 0 0;
+  padding: 3px 0 5px 0;
 
-    @include breakpoint(sm) {
-        font-size: 20px;
-        padding: 4px 0px;
-    }
+  @include breakpoint(sm) {
+    font-size: 20px;
+    padding: 4px 0px;
+  }
 }
 
 h4 {
-    font-size: 17px;
-    font-weight: 400;
-    line-height: 24px;
-    margin: ($baseline * 2) 0;
-    padding: 5px 0 3px 0;
+  font-size: 17px;
+  font-weight: 400;
+  line-height: 24px;
+  margin: ($baseline * 2) 0;
+  padding: 5px 0 3px 0;
 }
 
 h5 {
-    font-size: 16px;
-    font-weight: 700;
-    margin: ($baseline * 2) 0;
+  font-size: 16px;
+  font-weight: 700;
+  margin: ($baseline * 2) 0;
 }
 
 h6 {
-    font-size: 14px;
-    font-weight: 700;
-    margin: ($baseline * 2) 0 0 0;
+  font-size: 14px;
+  font-weight: 700;
+  margin: ($baseline * 2) 0 0 0;
 }
 
 p {
-    font-size: 14px;
-    font-weight: $base-font-weight;
-    line-height: 24px;
-    margin: ($baseline * 2) 0;
-    padding: 6px 0 10px 0;
+  font-size: 14px;
+  font-weight: $base-font-weight;
+  line-height: 24px;
+  margin: ($baseline * 2) 0;
+  padding: 6px 0 10px 0;
 }
 
-ul, ol {
-    margin: ($baseline * 2) 0;
-    padding-left: ($col * 1);
+ul,
+ol {
+  margin: ($baseline * 2) 0;
+  padding-left: ($col * 1);
 }
 
 li {
-    font-size: 14px;
-    font-weight: $base-font-weight;
-    line-height: 24px;
-    margin: ($baseline * 2) 0;
-    padding: 6px 0 10px 16px;
+  font-size: 14px;
+  font-weight: $base-font-weight;
+  line-height: 24px;
+  margin: ($baseline * 2) 0;
+  padding: 6px 0 10px 16px;
 }
 
 cite {
-    //
+  //
 }
 
 a {
-    text-decoration: none;
-    color: $matisse;
-    word-wrap: break-word;
+  text-decoration: none;
+  color: $matisse;
+  word-wrap: break-word;
 
-    &:hover,
-    &:focus {
-        text-decoration: underline;
-    }
+  &:hover,
+  &:focus {
+    text-decoration: underline;
+    box-shadow: 0 0 0 3px $carrot;
+    outline: 0;
+  }
 }
 
 address {
-    font-style: normal;
+  font-style: normal;
 }
 
-strong, .font-weight-700 {
-    font-weight: 700!important;
+strong,
+.font-weight-700 {
+  font-weight: 700 !important;
 }
 
 // Mixin for silent styling to bunch up spacing between elements in big blocks of text (ie markdown)
 @mixin markdown {
-    overflow: visible;
-    clear: both;
+  overflow: visible;
+  clear: both;
 
-    h4 {
-        font-weight: 700;
+  h4 {
+    font-weight: 700;
+  }
+
+  a {
+    text-decoration: underline;
+  }
+
+  p {
+    margin-top: 0;
+
+    &:empty {
+      display: none;
+    }
+  }
+
+  ul {
+    margin-top: 0;
+  }
+
+  img {
+    max-width: ($col * 38);
+  }
+
+  li {
+    margin: 0;
+
+    // li with only one p shouldn't have padding (spacing looks excessive)
+    p:first-of-type {
+      margin: 0;
+      padding: 0;
     }
 
-    a {
-        text-decoration: underline;
+    // to offset above styling second p in an li should have extra margin on the top (giving it the same styling as an ordinary p)
+    p:nth-of-type(2) {
+      @extend p;
+      margin-top: ($baseline * 2);
     }
-
-
-    p {
-        margin-top: 0;
-
-        &:empty {
-            display:none;
-        }
-
-    }
-
-    ul {
-        margin-top: 0;
-    }
-
-    img {
-        max-width: ($col * 38);
-    }
-
-    li {
-        margin: 0;
-
-        // li with only one p shouldn't have padding (spacing looks excessive)
-        p:first-of-type {
-            margin: 0;
-            padding: 0;
-        }
-
-        // to offset above styling second p in an li should have extra margin on the top (giving it the same styling as an ordinary p)
-        p:nth-of-type(2) {
-            @extend p;
-            margin-top: ($baseline * 2);
-        }
-
-    }
+  }
 }
 
 .markdown {
-    @include markdown
+  @include markdown;
 }
 
 @mixin font-heading-util {
-    .font-size {
-        @for $i from 1 through 6 {
-            //
-            &--h#{$i} {
-                @extend h#{$i};
-            }
-        }
+  .font-size {
+    @for $i from 1 through 6 {
+      //
+      &--h#{$i} {
+        @extend h#{$i};
+      }
     }
+  }
 }
 
 @include font-heading-util;


### PR DESCRIPTION
### What

Added new focus styles to all links on the website by attaching them to the anchor tag. I'm aware that links within sidebar sections, i.e: Publications that use this data, have their focus styles overlapping with the text. I'm suggesting that this should be looked at as part of a separate ticket to review the line-height or font-size of those links. However, if you feel that they should be fixed as part of this ticket, let me know.

### How to review

Serve the CSS within this PR to any page and tab through the content. Ensure that the focus styles are consistent. 

### Who can review

Matt Elcock worked on this PR. Anyone other than him may review.
