### PR TITLE
Refactored release banner class names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1050,7 +1050,7 @@
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
             "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
             "requires": {
-                "delayed-stream": "1.0.0"
+                "color-name": "1.1.3"
             }
         },
         "commander": {
@@ -1209,6 +1209,20 @@
                     "optional": true
                 }
             }
+        },
+        "css-url-regex": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/css-url-regex/-/css-url-regex-1.1.0.tgz",
+            "integrity": "sha1-g4NCMMyfdMRX3lnuvRVD/uuDt+w=",
+            "dev": true,
+            "optional": true
+        },
+        "css-what": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
+            "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
+            "dev": true,
+            "optional": true
         },
         "currently-unhandled": {
             "version": "0.4.1",
@@ -1733,7 +1747,6 @@
             "resolved": "https://registry.npmjs.org/executable/-/executable-4.1.1.tgz",
             "integrity": "sha512-8iA79xD3uAch729dUG8xaaBBFGaEa0wdD2VkYLFHwlqosEj/jT66AzcreRDSgV7ehnNLBW2WR5jIXwGKjVdTLg==",
             "dev": true,
-            "optional": true,
             "requires": {
                 "pify": "2.3.0"
             }
@@ -3033,6 +3046,18 @@
                 }
             }
         },
+        "ieee754": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+            "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+            "dev": true
+        },
+        "ignore": {
+            "version": "3.3.10",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+            "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+            "dev": true
+        },
         "imagemin-cli": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/imagemin-cli/-/imagemin-cli-4.0.1.tgz",
@@ -3551,6 +3576,12 @@
             "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
             "dev": true
         },
+        "is-plain-obj": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+            "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+            "dev": true
+        },
         "is-plain-object": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -3592,7 +3623,6 @@
             "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-3.0.0.tgz",
             "integrity": "sha512-gi4iHK53LR2ujhLVVj+37Ykh9GLqYHX6JOVXbLAucaG/Cqw9xwdFOjDM2qeifLs1sF1npXXFvDu0r5HNgCMrzQ==",
             "dev": true,
-            "optional": true,
             "requires": {
                 "html-comment-regex": "1.1.2"
             }
@@ -3658,7 +3688,6 @@
             "resolved": "https://registry.npmjs.org/jpegtran-bin/-/jpegtran-bin-4.0.0.tgz",
             "integrity": "sha512-2cRl1ism+wJUoYAYFt6O/rLBfpXNWG2dUWbgcEkTt5WGMnqI46eEro8T4C5zGROxKRqyKpCBSdHPvt5UYCtxaQ==",
             "dev": true,
-            "optional": true,
             "requires": {
                 "bin-build": "3.0.0",
                 "bin-wrapper": "4.1.0",
@@ -5139,6 +5168,7 @@
             "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
             "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "onetime": "2.0.1",
                 "signal-exit": "3.0.2"
@@ -5782,6 +5812,7 @@
             "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-2.0.0.tgz",
             "integrity": "sha1-awRGhWqbERTRhW/8vlCczLCXcmU=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "temp-dir": "1.0.0",
                 "uuid": "3.3.2"
@@ -5861,6 +5892,15 @@
                     "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
                     "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
                 }
+            }
+        },
+        "tough-cookie": {
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+            "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+            "requires": {
+                "psl": "1.1.31",
+                "punycode": "1.4.1"
             }
         },
         "tree-kill": {

--- a/scss/components/_alert.scss
+++ b/scss/components/_alert.scss
@@ -83,7 +83,11 @@
     }
 }
 
-.alert-bulletins {
+.alert-release-banner-col {
+    padding-bottom: ($baseline * 3);
+}
+
+.alert-release-banner {
     background-color: $white;
     color: $ship-grey;
     width: auto;
@@ -119,6 +123,7 @@
     &__link {
         font-size: 18px;
         display: inline-block;
+        
         @include breakpoint(sm) {
             font-size: 16px;
         }
@@ -138,6 +143,17 @@
         padding: 5px 0 10px 0;
         margin: 0;
         font-size: 17px
+    }
+}
+
+
+.alert-bulletins {
+    background-color: $white;
+    color: $ship-grey;
+    width: auto;
+
+    @media print {
+        display: none;
     }
 
     &--warning {

--- a/scss/components/_alert.scss
+++ b/scss/components/_alert.scss
@@ -83,10 +83,6 @@
     }
 }
 
-.alert-release-banner-col {
-    padding-bottom: ($baseline * 3);
-}
-
 .alert-release-banner {
     background-color: $white;
     color: $ship-grey;

--- a/scss/components/_page.scss
+++ b/scss/components/_page.scss
@@ -121,6 +121,14 @@
 	}
 }
 
+.page-compendium {
+	&_intro {
+		&-content {
+			padding-bottom: ($baseline * 2);
+		}
+	}
+}
+
 .page-bulletins {
 	a {
 		text-decoration: underline;


### PR DESCRIPTION
### What

As part of adding the release banner to compendiums the banner and header of pages have under gone a refactor to ensure that the code style is DRY. As a result some class names have now changed.

### How to review

* Check checkout the corresponding Babbage PR: https://github.com/ONSdigital/babbage/pull/307
* Check that the styling of bulletins release banner has not been changed
* Check that the bulletin previous and latest release banner is styled appropriately and with no negative effects on other elements
* Ensure that changes meet BEM requirements

### Who can review

Anyone except me