### PR TITLE
Fix for Visuals being chopped off the side of the screen

### DIFF
--- a/scss/components/_pym.scss
+++ b/scss/components/_pym.scss
@@ -11,7 +11,7 @@
     &--full-width {
         @include breakpoint(lg) {
             width: $col * 59; // 944px
-            margin-left: $col * -3;
+            margin-left: $col * -1;
         }
     }
 


### PR DESCRIPTION

### What

* margin on visuals have smaller (negative) margin on the left

### How to review

* Checkout this branch
* Checkout the develop branch of Babbage
* Check out how visual charts look, they should no longer be chopped off the side

### Who can review

Anyone except me 
