### PR TITLE
Additional Changes to the Typography

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -688,7 +688,7 @@
             "dev": true,
             "requires": {
                 "base64-js": "1.3.0",
-                "ieee754": "1.1.12"
+                "ieee754": "1.1.13"
             }
         },
         "buffer-alloc": {
@@ -1048,10 +1048,7 @@
         "combined-stream": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
-            "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
-            "requires": {
-                "color-name": "1.1.3"
-            }
+            "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w=="
         },
         "commander": {
             "version": "2.19.0",
@@ -1448,11 +1445,6 @@
             "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
             "integrity": "sha1-817qfXBekzuvE7LwOz+D2SFAOz4=",
             "dev": true
-        },
-        "delayed-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
         },
         "delegates": {
             "version": "1.0.0",
@@ -3013,9 +3005,9 @@
             }
         },
         "ieee754": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
-            "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+            "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
             "dev": true
         },
         "ignore": {
@@ -5945,9 +5937,9 @@
             "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
         },
         "uglify-js": {
-            "version": "3.5.1",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.1.tgz",
-            "integrity": "sha512-kI+3c+KphOAKIikQsZoT2oDsVYH5qvhpTtFObfMCdhPAYnjSvmW4oTWMhvDD4jtAGHJwztlBXQgozGcq3Xw9oQ==",
+            "version": "3.5.3",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.3.tgz",
+            "integrity": "sha512-rIQPT2UMDnk4jRX+w4WO84/pebU2jiLsjgIyrCktYgSvx28enOE3iYQMr+BD1rHiitWnDmpu0cY/LfIEpKcjcw==",
             "requires": {
                 "commander": "2.19.0",
                 "source-map": "0.6.1"

--- a/scss/elements/_sections.scss
+++ b/scss/elements/_sections.scss
@@ -1,308 +1,306 @@
 .section {
 
-	&__title {
-		margin-top: $baseline * 6;
-		margin-bottom: 0;
-	}
+    &__title {
+        margin-top: $baseline * 6;
+        margin-bottom: 0;
+    }
 
-	&__subtitle {
-		margin-top: $col;
-		margin-bottom: $baseline;
-	}
+    &__subtitle {
+        margin-top: $col;
+        margin-bottom: $baseline;
+    }
 
-	&__content {
+    &__content {
 
-		&-number {
-			position: relative;
-			margin-right: ($col);
-			//padding-left: 6px;
-			//width: ($col * 3);
-			display: block;
-			float: left;
+        &-number {
+            position: relative;
+            margin-right: ($col);
+            display: block;
+            float: left;
 
-			@include breakpoint(sm) {
-				margin-right: $col;
-				margin-left: 0;
-			}
+            @include breakpoint(sm) {
+                margin-right: $col;
+                margin-left: 0;
+            }
 
-		}
+        }
 
-		&--markdown {
+        &--markdown {
 
-			&:focus {
-				outline: none;
-			}
+            &:focus {
+                outline: none;
+            }
 
-			@include breakpoint(sm) {
-				padding: 0;
-			}
+            @include breakpoint(sm) {
+                padding: 0;
+            }
 
-			@include breakpoint(md) {
-				margin-right: ($col * 3);
-			}
+            @include breakpoint(md) {
+                margin-right: ($col * 3);
+            }
 
-			@include breakpoint(lg) {
-				margin-right: ($col * 2);
-			}
+            @include breakpoint(lg) {
+                margin-right: ($col * 2);
+            }
 
-			@include markdown;
+            @include markdown;
 
-			position: relative;
+            position: relative;
 
-			p {
-				font-size: 18px;
-				font-weight: 400;
-				line-height: 32px;
-				margin: 0 0 ($baseline * 3) 0;
-				padding: 0;
+            p {
+                font-size: 18px;
+                font-weight: 400;
+                line-height: 32px;
+                margin: 0 0 ($baseline * 3) 0;
+                padding: 0;
 
-				@include breakpoint(sm) {
-					font-size: 16px;
-				}
-			}
+                @include breakpoint(sm) {
+                    font-size: 16px;
+                }
+            }
 
-			ul, ol {
-				margin-bottom: ($baseline * 4);
-  				padding-left: ($col * 2);
-			}
+            ul, ol {
+                margin-bottom: ($baseline * 4);
+                  padding-left: ($col * 2);
+            }
 
-			li {
-				margin: 0 0 $baseline 0;
-				line-height: 32px;
-				font-weight: 400;
-				font-size: 18px;
-				padding: 0;
-				@include breakpoint(sm) {
-					font-size: 16px;
-				}
-			}
+            li {
+                margin: 0 0 $baseline 0;
+                line-height: 32px;
+                font-weight: 400;
+                font-size: 18px;
+                padding: 0;
+                @include breakpoint(sm) {
+                    font-size: 16px;
+                }
+            }
 
-			a {
-				text-decoration: underline;
-				font-size: 18px;
-				font-weight: 400;
-				line-height: 32px;
-				@include breakpoint(sm) {
-					font-size: 16px;
-				}
-			  }
-			
-			// All headings should be bold. They should have padding above, 
-			// but only if not under a heading equal or lower level to itself
-			@for $i from 1 through 6 {
-				h#{$i} {
-				 	padding: ($baseline * 3) 0 0 0;
-					font-weight: bold;
-					@if $i < 3 {
-						line-height: (40px);
-						@include breakpoint(sm) {
-							line-height: 32px;
-						}
-					} @else {
-						line-height: (32px);
-						@include breakpoint(sm) {
-							line-height: 24px;
-						}
-					}
-				}
+            a {
+                text-decoration: underline;
+                font-size: 18px;
+                font-weight: 400;
+                line-height: 32px;
+                @include breakpoint(sm) {
+                    font-size: 16px;
+                }
+              }
 
-				// Remove padding on sibling subheadings 
-				@for $j from $i through 6 {
-					h#{$i} + h#{$j} {
-						padding-top: 0;
-				   }
-				}
-			}
+            h1, h2 {
+                font-size: 30px;
+                margin: ($baseline * 4) 0 ($baseline * 4) 0;
+                padding: ($baseline * 3) 0 0 0;
+                font-weight: bold;
+                line-height: (40px);
+                @include breakpoint(sm) {
+                    font-size: 24px;
+                    margin: ($baseline * 3) 0 ($baseline * 2) 0;
+                    line-height: 32px;
+                }
+            }
 
-			h1, h2 {
-				font-size: 30px;
-				margin: ($baseline * 4) 0 ($baseline * 4) 0;
-				@include breakpoint(sm) {
-					font-size: 24px;
-					margin: ($baseline * 3) 0 ($baseline * 2) 0;
-				}
-			}
+            h3 {
+                font-size: 24px;
+                margin: ($baseline * 4) 0 ($baseline * 2) 0;
+                padding: ($baseline * 3) 0 0 0;
+                font-weight: bold;
+                line-height: 32px;
+                @include breakpoint(sm) {
+                    font-size: 18px;
+                    line-height: 24px;
+                    margin: ($baseline * 3) 0 ($baseline * 2) 0;
+                }
+            }
 
-			h3 {
-				font-size: 24px;
-				margin: ($baseline * 4) 0 ($baseline * 2) 0;
-				@include breakpoint(sm) {
-					font-size: 18px;
-					margin: ($baseline * 3) 0 ($baseline * 2) 0;
-				}
-			}
+            h4 {
+                font-size: 18px;
+                margin: ($baseline *3) 0 ($baseline * 2) 0;
+                padding: ($baseline * 3) 0 0 0;
+                font-weight: bold;
+                line-height: 32px;
+                @include breakpoint(sm) {
+                    font-size: 16px;
+                    line-height: 24px;
+                    margin: ($baseline * 2) 0 ($baseline * 2) 0;
+                }
+            }
 
-			h4 {
-				font-size: 18px;
-				margin: ($baseline *3) 0 ($baseline * 2) 0;
-				@include breakpoint(sm) {
-					font-size: 16px;
-					margin: ($baseline * 2) 0 ($baseline * 2) 0;
-				}
-			}
+            h5, h6 {
+                    font-size: 16px;
+                    margin: ($baseline * 2) 0 ($baseline) 0;
+                    @include breakpoint(sm) {
+                        margin: ($baseline * 2) 0 ($baseline * 2) 0;
+                    }
+            }
 
-			h5, h6 {
-					font-size: 16px;
-					margin: ($baseline * 2) 0 ($baseline) 0;
-					@include breakpoint(sm) {
-						margin: ($baseline * 2) 0 ($baseline * 2) 0;
-					}
-			}
+            // All 1-4 headings should be bold. They should have padding above, 
+            // but only if not under a heading equal or lower level to itself
+            @for $i from 1 through 4 {
+                @for $j from $i through 6 {
+                    h#{$i} + h#{$j} {
+                        padding-top: 0;
+                   }
+                }
+            }
 
-			// Special instances of headings
+            // Special instances of headings
 
+            // Sub headings
+            header + h3  {
+                padding-top: 0;
+            }
 
+            // Chart subtitles
+            h4 + h5  {
+                margin: 0 0 ($baseline * 2) 0;
+                font-weight: normal;
+                font-size: 16px;
+                @include breakpoint(sm) {
+                    font-size: 14px;
+                }
+            }
 
-			// Chart subtitles
-			h4 + h5  {
-				margin: ($baseline *3) 0 ($baseline * 2) 0;
-				font-weight: normal;
-				font-size: 18px;
-				@include breakpoint(sm) {
-					font-size: 16px;
-				}
-			}
-			
-			// Bullet points under a charts note title
-			h5 + ol, h5 + ul, h6 + ol, h6 + li {
-				margin-top: $baseline;
-			}
+            .markdown-chart-container > h4:first-of-type {
+                margin-bottom: $baseline;
+            }
 
-			.font-xsmall {
-				font-size: 14px;
-				line-height: 24px;
-			}
-		
-			.markdown-chart-container, .markdown-table-container {
-				margin-bottom: ($baseline * 4);
+            // Bullet points under a charts note title
+            h5 + ol, h5 + ul, h6 + ol, h6 + li {
+                margin-top: $baseline;
+            }
 
+            .font-xsmall {
+                font-size: 14px;
+                line-height: 24px;
+            }
+        
+            .markdown-chart-container, .markdown-table-container {
+                margin-bottom: ($baseline * 4);
 
-				//On mobile remove grey border
-				@include breakpoint(sm) {
-						border-left: 0;
-					}
+                //On mobile remove grey border
+                @include breakpoint(sm) {
+                        border-left: 0;
+                    }
 
-				&--error {
-					height: ($baseline * 36);
-					font-size: 17px;
-					font-weight: 600;
-					position: relative;
-					text-align: center;
-				}
+                &--error {
+                    height: ($baseline * 36);
+                    font-size: 17px;
+                    font-weight: 600;
+                    position: relative;
+                    text-align: center;
+                }
 
-				&--error__message {
-					position: absolute;
-					top: ($baseline * 16);
-					left: 0;
-					width: 100%;
-					text-align: center;
-					padding: 5px 0 3px 0;
-				}
+                &--error__message {
+                    position: absolute;
+                    top: ($baseline * 16);
+                    left: 0;
+                    width: 100%;
+                    text-align: center;
+                    padding: 5px 0 3px 0;
+                }
 
+                .markdown-table-wrap {
+                    //Charts take up extra space when available (ie on desktop/tablet)
+                    width: 700px;
+                    
+                    // Slightly smaller on medium so that table right column isn't cut off
+                    @include breakpoint(md) {
+                        width: 670px;
+                    }
 
-				.markdown-table-wrap {
-					//Charts take up extra space when available (ie on desktop/tablet)
-					width: 700px;
-					
-					// Slightly smaller on medium so that table right column isn't cut off
-					@include breakpoint(md) {
-						width: 670px;
-					}
+                    //On mobile then go 100% width
+                    @include breakpoint(sm) {
+                        width: 100%;
+                    }
+                }
+                .markdown-chart{
+                    //Charts take up extra space when available (ie on desktop/tablet)
+                    width: 700px;
 
-					//On mobile then go 100% width
-					@include breakpoint(sm) {
-						width: 100%;
-					}
-				}
-				.markdown-chart{
-					//Charts take up extra space when available (ie on desktop/tablet)
-					width: 700px;
+                    //On tablet
+                    @include breakpoint(md) {
+                        width: 520px;
+                    }
+                    //On mobile 
+                    @include breakpoint(sm) {
+                        width: 360px;
+                    }
+                }
+                .sm-multiple-holder {
+                    // set the holder to max width: 3 small line charts
+                    width: 700px;
+                    /*
+                    // 2 small line chart on tablet?
+                    @include breakpoint(md) {
+                        width: 500px;
+                    }
+                    */
+                }
 
-					//On tablet
-					@include breakpoint(md) {
-						width: 520px;
-					}
-					//On mobile 
-					@include breakpoint(sm) {
-						width: 360px;
-					}
-				}
-				.sm-multiple-holder {
-					// set the holder to max width: 3 small line charts
-					width: 700px;
-					/*
-					// 2 small line chart on tablet?
-					@include breakpoint(md) {
-						width: 500px;
-					}
-					*/
-				}
+                .sm-multiple {
+                    padding-top:4px;
+                    width: 230px;
+                    float:left;
+                }
+            }
 
-				.sm-multiple {
-					padding-top:4px;
-					width: 230px;
-					float:left;
-				}
-			}
+            .markdown-chart-container{
+                padding-left:0;
+            }
 
-			.markdown-chart-container{
-				padding-left:0;
-			}
+            .markdown-box-container {
+                background-color: $gallery;
+                padding: ($baseline * 2) $col;
+                margin-bottom: $baseline * 2;
 
-			.markdown-box-container {
-				background-color: $gallery;
-				padding: ($baseline * 2) $col;
-				margin-bottom: $baseline * 2;
+                // remove margin top and bottom from first and last items
+                // can't use :first-child because the markdown parser sometimes leaves empty p tag first :(
+                h3:first-of-type,
+                h4:first-of-type {
+                    margin-top: 0;
+                }
 
-				// remove margin top and bottom from first and last items
-				// can't use :first-child because the markdown parser sometimes leaves empty p tag first :(
-				h3:first-of-type,
-				h4:first-of-type {
-					margin-top: 0;
-				}
+                *:last-child {
+                    margin-bottom: 0;
+                }
+            }
 
-				*:last-child {
-					margin-bottom: 0;
-				}
-			}
+            .markdown-warning-box {
+                &--container {
+                    background-color: $white;
+                    padding: ($baseline * 1) 0;
+                    position: relative;
+                    margin-bottom: 24px;
+                }
 
-			.markdown-warning-box {
-				&--container {
-					background-color: $white;
-					padding: ($baseline * 1) 0;
-					position: relative;
-					margin-bottom: 24px;
-				}
+                &--icon {
+                    font-weight: 700;
+                    display: inline-block;
+                    position: absolute;
+                    top: 50%;
+                    left: 0;
+                    padding-top: 1px;
+                    min-width: 38px;
+                    min-height: 38px;
+                    margin-top: -19px;
+                    font-size: 26px;
+                    border: 3px solid #323132;
+                    border-radius: 50%;
+                    color: #fff;
+                    background: #323132;
+                    line-height: 29px;
+                    text-align: center;
+                }
 
-				&--icon {
-					font-weight: 700;
-					display: inline-block;
-					position: absolute;
-					top: 50%;
-					left: 0;
-					padding-top: 1px;
-					min-width: 38px;
-					min-height: 38px;
-					margin-top: -19px;
-					font-size: 26px;
-					border: 3px solid #323132;
-					border-radius: 50%;
-					color: #fff;
-					background: #323132;
-					line-height: 29px;
-					text-align: center;
-				}
-
-				&--text {
-					p {
-						font-weight: 700;
-						margin-bottom: ($baseline * 3);
-						padding: 0;
-						font-size: 18px;
-						line-height: 32px;
-					}
-				}
-			}
+                &--text {
+                    p {
+                        font-weight: 700;
+                        margin-bottom: ($baseline * 3);
+                        padding: 0;
+                        font-size: 18px;
+                        line-height: 32px;
+                    }
+                }
+            }
 
             // Neutral article specific styling
             &--neutral-article {
@@ -312,20 +310,20 @@
             }
             // End of Neutral article specific styling
 
-		}
+        }
 
-		&--static-markdown {
-			@include markdown;
+        &--static-markdown {
+            @include markdown;
 
-			margin-top: ($baseline * 3);
+            margin-top: ($baseline * 3);
 
-			ol, ul {
-				margin: $col 0 $col $col;
-				padding-left: $col;
-			}
+            ol, ul {
+                margin: $col 0 $col $col;
+                padding-left: $col;
+            }
 
-		}
+        }
 
-	}
+    }
 
 }


### PR DESCRIPTION
### What

* Replaced tabs with four white space characters in _sections.scss file
* Add margin to bottom of article; gives the 'Back to table of contents' empty space underneath.
* Chart sub headings if h5 has a lower font size than paragraph text
* Chart title and subtitle gap made smaller 8px
* Remove majority of new styling for h5 tags
* Remove padding on sub headings of headings contained within the heading tag e.g. 
`<header><h3></header><h4>`

### How to review

Check out this branch of sixteens and make sure that the above visual changes are accurate and true. Nothing else is effected that shouldn't have been. That the code is clean.

### Who can review

Anyone on the Dev team except me