### PR TITLE
CMD typography fixes for

### DIFF
--- a/scss/elements/_lists.scss
+++ b/scss/elements/_lists.scss
@@ -21,24 +21,30 @@
 	}
 
 	&--pipe-seperated {
-		list-style:none;
-		margin:0;
-		padding:0;
-		display: inline;
-		//ellipses sm
-		&-ellipses{
-			@include breakpoint(sm) {
-				position: relative;
-				display: inline-block;
-				&:after {
-					content: "";
-					background-color: white;
-					position: absolute;
-					right: -800px;
-					top: 0;
-					width: 800px;
-					height: 1.5em;
-					z-index: 4;
+		ul, ol, dl {
+			list-style:none;
+			margin:0;
+			padding:0;
+			display: inline;
+			//ellipses sm
+			&-ellipses {
+				margin:0;
+				padding:0;
+				display: inline;
+				list-style:none;
+				@include breakpoint(sm) {
+					position: relative;
+					display: inline-block;
+					&:after {
+						content: "";
+						background-color: white;
+						position: absolute;
+						right: -800px;
+						top: 0;
+						width: 800px;
+						height: 1.5em;
+						z-index: 4;
+					}
 				}
 			}
 		}
@@ -102,7 +108,7 @@
 	&--custom-numbered {
 		@if $old-ie != true {
 			list-style: none;
-			padding:0;
+			padding: 0;
 			> li {
 				counter-increment: step-counter;
 				padding: 0;
@@ -110,13 +116,14 @@
 				position: relative;
 				&::before {
 					content: counter(step-counter)'.';
-					font-size:24px;
-					font-weight:bold;
+					font-size: 30px;
+					font-weight: bold;
 					position: absolute;
-					top:0;
-					left:0;
+					top: $baseline;
+					left: 0;
 					@include breakpoint(sm) {
-							font-size: 22px;
+							font-size: 24px;
+							top: 4px;
 					}
 				}
 				// If the list contains a separate list, don't follow the ul ul style

--- a/scss/elements/_sections.scss
+++ b/scss/elements/_sections.scss
@@ -167,17 +167,6 @@
 			h5 + ol, h5 + ul, h6 + ol, h6 + li {
 				margin-top: $baseline;
 			}
-
-			.cmd-heading {
-				padding-left: ($baseline * 6);
-				@include breakpoint(sm) { 
-					padding-left: ($baseline * 4);
-				}
-			}
-
-			.cmd-list {
-				padding: 0px;
-			}
 		
 			.font-xsmall {
 				font-size: 14px;

--- a/scss/elements/_sections.scss
+++ b/scss/elements/_sections.scss
@@ -154,7 +154,7 @@
 
 
 			// Chart subtitles
-			h4 + h5  {
+			h4 + h5 {
 				margin: ($baseline *3) 0 ($baseline * 2) 0;
 				font-weight: normal;
 				font-size: 18px;
@@ -168,6 +168,17 @@
 				margin-top: $baseline;
 			}
 
+			.cmd-heading {
+				padding-left: ($baseline * 6);
+				@include breakpoint(sm) { 
+					padding-left: ($baseline * 4);
+				}
+			}
+
+			.cmd-list {
+				padding: 0px;
+			}
+		
 			.font-xsmall {
 				font-size: 14px;
 				line-height: 24px;
@@ -323,9 +334,7 @@
 				margin: $col 0 $col $col;
 				padding-left: $col;
 			}
-
 		}
-
 	}
 
 }


### PR DESCRIPTION
### What

Typography broke CMD styling.
Why? - CMD filterable template is using markdown styling.
Items which were broken and should now be fixed with this PR are:
* Headings are tabbed in
* Subheadings top padding removed
* List styling no longer appearing 'oddly' tabbed

### How to review

1. Checkout this branch and the following for dp-fronted-renderer PR/Branch: https://github.com/ONSdigital/dp-frontend-renderer/pull/278
2. Run the CMD tech stack
3. Check that CMD content pages look as they should
4. Run the standard tech stack
5. Check that Articles (+Neutral), Compendiums and Bulletins still follow the new typography rules

### Who can review

Anyone on the developer team, ideally Frontend Dev except me.