### PR TITLE
Fix for filterable pages having filter options chopped off

### DIFF
--- a/scss/elements/_lists.scss
+++ b/scss/elements/_lists.scss
@@ -21,31 +21,31 @@
 	}
 
 	&--pipe-seperated {
-		ul, ol, dl {
-			list-style:none;
+		&-ellipses {
 			margin:0;
 			padding:0;
 			display: inline;
-			//ellipses sm
-			&-ellipses {
+			list-style:none;
+			@include breakpoint(sm) {
+				position: relative;
+				display: inline-block;
+				&:after {
+					content: "";
+					background-color: white;
+					position: absolute;
+					right: -800px;
+					top: 0;
+					width: 800px;
+					height: 1.5em;
+					z-index: 4;
+				}
+			}
+			ul, ol, dl {
+				list-style:none;
 				margin:0;
 				padding:0;
 				display: inline;
-				list-style:none;
-				@include breakpoint(sm) {
-					position: relative;
-					display: inline-block;
-					&:after {
-						content: "";
-						background-color: white;
-						position: absolute;
-						right: -800px;
-						top: 0;
-						width: 800px;
-						height: 1.5em;
-						z-index: 4;
-					}
-				}
+				//ellipses sm
 			}
 		}
 		li {


### PR DESCRIPTION
### What

Filter page `list--pipe-seperated-ellipses` CSS no longer existed due to a previous change, as such default margin of 16px was being applied. This CSS is now back and was not present due to a previous refactor. It should now look like:

<img width="472" alt="Screenshot 2019-07-09 at 12 03 58" src="https://user-images.githubusercontent.com/47502916/60883270-a9642f80-a241-11e9-900a-d9bc7ed3e8b5.png">

### How to review

Checkout the branch, check lists in all areas of the website, articles, CMD, filter pages etc and ensure that all lists look as they should and nothing else has broken.

### Who can review

Anyone else except me