### PR TITLE
Fix the iron-grey colour on small view, links text

### DIFF
--- a/scss/components/_language-toggle.scss
+++ b/scss/components/_language-toggle.scss
@@ -18,9 +18,6 @@
 
     &__link {
         text-decoration: underline;
-        @include breakpoint(sm) {
-            color: $iron-light;
-        }
     }
 
     // Styles for js enhanced <select> form


### PR DESCRIPTION
### What

The colour of font should not change when links are small, this PR removes this iron-grey change of colour when viewed on small width viewports. Note that language links are also set currently to have the class `hide--sm` which hides them when they are small. This PR is part of a fix to show language toggles when on mobile devices (and viewing via a narrow viewport). If the CSS to remove the hide on small viewports is removed then the text is the wrong colour as seen below:
<img width="621" alt="Screenshot 2019-09-02 at 10 44 08" src="https://user-images.githubusercontent.com/47502916/64106630-76857600-cd70-11e9-8b79-c655704dc6db.png">

### How to review

1. Checkout PR
2. Visit 404, 501, CMD, BAU pages
3. Change viewport to a narrow width <767
4. Disable the following CSS
<img width="734" alt="Screenshot 2019-09-02 at 10 56 12" src="https://user-images.githubusercontent.com/47502916/64106599-6e2d3b00-cd70-11e9-979d-731e823823f6.png">
Ensure that the colour of the text is the same as that when not on a small viewport (blue).

### Who can review

Anyone except me
