### PR TITLE
Added sticky footer styling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -111,9 +111,9 @@
             "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
         },
         "anymatch": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.0.3.tgz",
-            "integrity": "sha512-c6IvoeBECQlMVuYUjSwimnhmztImpErfxJzWZhIQinIvQWoGOnB0dLIgifbPHQt5heS6mNlaZG16f06H3C8t1g==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+            "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
             "dev": true,
             "requires": {
                 "normalize-path": "^3.0.0",
@@ -791,19 +791,30 @@
             }
         },
         "chokidar": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.0.2.tgz",
-            "integrity": "sha512-c4PR2egjNjI1um6bamCQ6bUNPDiyofNQruHvKgHQ4gDUP/ITSVSzNsiI5OWtHOsX323i5ha/kk4YmOZ1Ktg7KA==",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.1.tgz",
+            "integrity": "sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==",
             "dev": true,
             "requires": {
-                "anymatch": "^3.0.1",
-                "braces": "^3.0.2",
-                "fsevents": "^2.0.6",
-                "glob-parent": "^5.0.0",
-                "is-binary-path": "^2.1.0",
-                "is-glob": "^4.0.1",
-                "normalize-path": "^3.0.0",
-                "readdirp": "^3.1.1"
+                "anymatch": "~3.1.1",
+                "braces": "~3.0.2",
+                "fsevents": "~2.1.2",
+                "glob-parent": "~5.1.0",
+                "is-binary-path": "~2.1.0",
+                "is-glob": "~4.0.1",
+                "normalize-path": "~3.0.0",
+                "readdirp": "~3.3.0"
+            },
+            "dependencies": {
+                "glob-parent": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+                    "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+                    "dev": true,
+                    "requires": {
+                        "is-glob": "^4.0.1"
+                    }
+                }
             }
         },
         "cli-cursor": {
@@ -1800,9 +1811,9 @@
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "fsevents": {
-            "version": "2.0.7",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.0.7.tgz",
-            "integrity": "sha512-a7YT0SV3RB+DjYcppwVDLtn13UQnmg0SWZS7ezZD0UjnLwXmy8Zm21GMVGLaFGimIqcvyMQaOJBrop8MyOp1kQ==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+            "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
             "dev": true,
             "optional": true
         },
@@ -3327,17 +3338,18 @@
             }
         },
         "onchange": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/onchange/-/onchange-6.0.0.tgz",
-            "integrity": "sha512-1b6FRfV0otr4gj/mWPlEAPnsxvHLDFmL4nFCbnNYLgPpiy+bNmoDdpD80iXK63mIBqU1S5+d4oAEffFqN68wvA==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/onchange/-/onchange-6.1.0.tgz",
+            "integrity": "sha512-T0wvi3yzNd+Lut2ymJp2e6fTiob0TLrXnjqGaiK9MAFB8MYo/k/ZClx6ps7YhTtQ88dDm+hDHmtJXP1nJT5WNA==",
             "dev": true,
             "requires": {
                 "@blakeembrey/deque": "^1.0.3",
                 "arrify": "^2.0.0",
                 "chokidar": "^3.0.0",
                 "cross-spawn": "^6.0.0",
+                "ignore": "^5.1.4",
                 "minimist": "^1.2.0",
-                "supports-color": "^6.0.0",
+                "supports-color": "^7.0.0",
                 "tree-kill": "^1.2.0"
             },
             "dependencies": {
@@ -3354,13 +3366,25 @@
                         "which": "^1.2.9"
                     }
                 },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "ignore": {
+                    "version": "5.1.4",
+                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+                    "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+                    "dev": true
+                },
                 "supports-color": {
-                    "version": "6.1.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "^4.0.0"
                     }
                 }
             }
@@ -3821,12 +3845,12 @@
             }
         },
         "readdirp": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.1.1.tgz",
-            "integrity": "sha512-XXdSXZrQuvqoETj50+JAitxz1UPdt5dupjT6T5nVB+WvjMv2XKYj+s7hPeAVCXvmJrL36O4YYyWlIC3an2ePiQ==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.3.0.tgz",
+            "integrity": "sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==",
             "dev": true,
             "requires": {
-                "picomatch": "^2.0.4"
+                "picomatch": "^2.0.7"
             }
         },
         "redent": {
@@ -4535,9 +4559,9 @@
             }
         },
         "tree-kill": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.1.tgz",
-            "integrity": "sha512-4hjqbObwlh2dLyW4tcz0Ymw0ggoaVDMveUB9w8kFSQScdRLo0gxO9J7WFcUBo+W3C1TLdFIEwNOWebgZZ0RH9Q==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+            "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
             "dev": true
         },
         "trim-newlines": {

--- a/scss/components/_footer.scss
+++ b/scss/components/_footer.scss
@@ -4,6 +4,11 @@
 	background-color: $ship-grey;
 	color: $iron-light;
 
+	&-sticky {
+		bottom: 0;
+		width: 100%;
+	}
+
 	a {
 		color: $iron;
 		text-decoration: underline;
@@ -43,13 +48,13 @@
 		border-top: 1px solid $silver;
 		padding: $col*2 0 $col 0;
 
-			&__img {
-				display: inline-block;
-			}
+		&__img {
+			display: inline-block;
+		}
 
-			&__text {
-				display: inline-block;
-				margin: $col 0 $col $col;
-			}
+		&__text {
+			display: inline-block;
+			margin: $col 0 $col $col;
+		}
 	}
 }

--- a/scss/components/_footer.scss
+++ b/scss/components/_footer.scss
@@ -4,7 +4,7 @@
 	background-color: $ship-grey;
 	color: $iron-light;
 
-	&-sticky {
+	&--sticky {
 		bottom: 0;
 		width: 100%;
 	}

--- a/scss/components/_header.scss
+++ b/scss/components/_header.scss
@@ -378,7 +378,7 @@
     position: relative; // So language toggle has relative parent
     height: ($baseline * 9);
 
-    &-separator {
+    &--separator {
         background-color: $ship-grey;
         height: 2px;
     }

--- a/scss/components/_header.scss
+++ b/scss/components/_header.scss
@@ -377,6 +377,11 @@
     padding: 15px 0 9px 0;
     position: relative; // So language toggle has relative parent
     height: ($baseline * 9);
+
+    &-separator {
+        background-color: $ship-grey;
+        height: 2px;
+    }
 }
 
 // Logo

--- a/scss/components/_main.scss
+++ b/scss/components/_main.scss
@@ -1,7 +1,7 @@
 //main.scss
 
 .main {
-  &-sticky-footer-offset {
-    padding-bottom: 198px;
+  &--sticky-footer-offset {
+    padding-bottom: $baseline * 25
   }
 }

--- a/scss/components/_main.scss
+++ b/scss/components/_main.scss
@@ -1,0 +1,7 @@
+//main.scss
+
+.main {
+  &-sticky-footer-offset {
+    padding-bottom: 198px;
+  }
+}

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -39,6 +39,7 @@ $old-ie: false;
 
 
 @import "components/header";
+@import "components/main";
 @import "components/banner";
 @import "components/slates";
 @import "components/breadcrumb";


### PR DESCRIPTION
### What

Sticky footer support added
Currently, footers don't stick to the bottom of the content

To use the `main-sticky-footer-offset` class needs to be added to the content above and the footer needs the class `footer-sticky` added to it

Some pages now need to have a header separator when the usual top bar does not appear, this has been added as `header-separator` class

Small file format correction on `footer-a__img` and `footer-a__text`

### How to review
Check that the styling is using correct units
Check that there are not possible ways to achieve the above with current classes
Ensure that the changes follow BEM (Block Element Modifier)

### Who can review

Anyone except me
