### PR TITLE
Updated banner styling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -85,9 +85,9 @@
             "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
         },
         "ajv": {
-            "version": "6.10.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-            "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+            "version": "6.10.2",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+            "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
             "requires": {
                 "fast-deep-equal": "^2.0.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -247,9 +247,9 @@
             "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
         },
         "aws4": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-            "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
+            "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
         },
         "balanced-match": {
             "version": "1.0.0",
@@ -919,7 +919,6 @@
             "version": "1.9.3",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
             "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-            "dev": true,
             "requires": {
                 "color-name": "1.1.3"
             }
@@ -927,13 +926,7 @@
         "color-name": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-            "dev": true
-        },
-        "colors": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.4.tgz",
-            "integrity": "sha512-6Y+iBnWmXL+AWtlOp2Vr6R2w5MUlNJRwR0ShVFaAb1CqWzhPOpQg4L0jxD+xpw/Nc8QJwaq3KM79QUCriY8CWQ=="
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
         "combined-stream": {
             "version": "1.0.8",
@@ -944,9 +937,9 @@
             }
         },
         "commander": {
-            "version": "2.20.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-            "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
         },
         "concat-map": {
             "version": "0.0.1",
@@ -1675,9 +1668,9 @@
             }
         },
         "fast-json-stable-stringify": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
         },
         "fastq": {
             "version": "1.6.0",
@@ -1818,9 +1811,9 @@
             "optional": true
         },
         "fstream": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-            "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+            "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
             "requires": {
                 "graceful-fs": "^4.1.2",
                 "inherits": "~2.0.0",
@@ -1946,9 +1939,9 @@
             }
         },
         "globule": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
-            "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/globule/-/globule-1.3.0.tgz",
+            "integrity": "sha512-YlD4kdMqRCQHrhVdonet4TdRtv1/sZKepvoxNT4Nrhrp5HI8XFfc8kFlGlBn2myBo80aGp8Eft259mbcUJhgSg==",
             "requires": {
                 "glob": "~7.1.1",
                 "lodash": "~4.17.10",
@@ -2046,8 +2039,7 @@
         "has-flag": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-            "dev": true
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "has-symbol-support-x": {
             "version": "1.4.2",
@@ -2849,9 +2841,9 @@
             }
         },
         "lodash": {
-            "version": "4.17.11",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-            "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+            "version": "4.17.15",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+            "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
         },
         "log-symbols": {
             "version": "2.2.0",
@@ -3038,14 +3030,23 @@
         "mime-db": {
             "version": "1.40.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-            "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
+            "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
+            "dev": true,
+            "optional": true
         },
         "mime-types": {
-            "version": "2.1.24",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
-            "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+            "version": "2.1.26",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+            "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
             "requires": {
-                "mime-db": "1.40.0"
+                "mime-db": "1.43.0"
+            },
+            "dependencies": {
+                "mime-db": {
+                    "version": "1.43.0",
+                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+                    "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+                }
             }
         },
         "mimic-fn": {
@@ -3119,9 +3120,9 @@
             "dev": true
         },
         "nan": {
-            "version": "2.13.2",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-            "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
+            "version": "2.14.0",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+            "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
         },
         "nice-try": {
             "version": "1.0.5",
@@ -3155,9 +3156,9 @@
             }
         },
         "node-sass": {
-            "version": "4.12.0",
-            "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.12.0.tgz",
-            "integrity": "sha512-A1Iv4oN+Iel6EPv77/HddXErL2a+gZ4uBeZUy+a8O35CFYTXhgA8MgLCWBtwpGZdCvTvQ9d+bQxX/QC36GDPpQ==",
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.13.0.tgz",
+            "integrity": "sha512-W1XBrvoJ1dy7VsvTAS5q1V45lREbTlZQqFbiHb3R3OTTCma0XBtuG6xZ6Z4506nR4lmHPTqVRwxT6KgtWC97CA==",
             "requires": {
                 "async-foreach": "^0.1.3",
                 "chalk": "^1.1.1",
@@ -3166,7 +3167,7 @@
                 "get-stdin": "^4.0.1",
                 "glob": "^7.0.3",
                 "in-publish": "^2.0.0",
-                "lodash": "^4.17.11",
+                "lodash": "^4.17.15",
                 "meow": "^3.7.0",
                 "mkdirp": "^0.5.1",
                 "nan": "^2.13.2",
@@ -3572,9 +3573,9 @@
             "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg=="
         },
         "p-limit": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-            "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+            "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
             "requires": {
                 "p-try": "^2.0.0"
             }
@@ -3764,9 +3765,9 @@
             "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
         },
         "psl": {
-            "version": "1.1.31",
-            "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-            "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
+            "integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ=="
         },
         "pump": {
             "version": "3.0.0",
@@ -3871,13 +3872,13 @@
             }
         },
         "replace": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/replace/-/replace-1.1.0.tgz",
-            "integrity": "sha512-0k9rtPG0MUDfJj77XtMCSJKOPdzSwVwM79ZQ6lZuFjqqXrQAMKIMp0g7/8GDAzeERxdktV/LzqbMtJ3yxB23lg==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/replace/-/replace-1.1.5.tgz",
+            "integrity": "sha512-Mww6GyTix4GqN1GSbJDkUzftkjQE0xfzzlGkFF26ukm8DBzgwGPFntvmVsvAKJogwSSMjvAoZei7fJ2tfiKMcA==",
             "requires": {
-                "colors": "1.2.4",
+                "chalk": "2.4.2",
                 "minimatch": "3.0.4",
-                "yargs": "12.0.5"
+                "yargs": "^12.0.5"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -3885,10 +3886,28 @@
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
                     "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
                 },
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
                 "camelcase": {
                     "version": "5.3.1",
                     "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
                     "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
                 },
                 "cliui": {
                     "version": "4.1.0",
@@ -3951,6 +3970,14 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "requires": {
                         "ansi-regex": "^3.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "requires": {
+                        "has-flag": "^3.0.0"
                     }
                 },
                 "which-module": {
@@ -4470,12 +4497,12 @@
             }
         },
         "tar": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-            "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+            "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
             "requires": {
                 "block-stream": "*",
-                "fstream": "^1.0.2",
+                "fstream": "^1.0.12",
                 "inherits": "2"
             }
         },
@@ -4601,11 +4628,11 @@
             "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
         },
         "uglify-js": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
-            "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+            "version": "3.7.5",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.5.tgz",
+            "integrity": "sha512-GFZ3EXRptKGvb/C1Sq6nO1iI7AGcjyqmIyOw0DrD0675e+NNbGO72xmMM2iEBdFbxaTLo70NbjM/Wy54uZIlsg==",
             "requires": {
-                "commander": "~2.20.0",
+                "commander": "~2.20.3",
                 "source-map": "~0.6.1"
             },
             "dependencies": {

--- a/scss/components/_banner.scss
+++ b/scss/components/_banner.scss
@@ -33,13 +33,13 @@
         font-size: 16px;
         position: relative;
         top: 50%;
-        transform: translateY(50%);
 
         @include breakpoint(sm) {
             display: block;
             float: left;
             margin-top: 8px;
             margin-right: 8px;
+            transform: translateY(50%);
         }
     }
 

--- a/scss/components/_banner.scss
+++ b/scss/components/_banner.scss
@@ -1,17 +1,17 @@
 .banner {
     background-color: $white;
 
-    &--prototype {
+    &--carrot {
         background-color: $carrot;
         color: $white;
     }
 
-    &__wrapper {
+    &--bottom-border {
         border-bottom: 1px solid $iron;
+    }
 
-        &--prototype {
-            border-bottom: none;
-        }
+    &--no-border {
+        border-bottom: none;
     }
 
     &__icon {
@@ -45,6 +45,7 @@
 
     &__body {
         display: flex;
+        display: -ms-flexbox;
         padding-bottom: $baseline;
         
         @include breakpoint(md) {

--- a/scss/components/_banner.scss
+++ b/scss/components/_banner.scss
@@ -1,6 +1,18 @@
 .banner {
-    background-color: $astral;
-    color: $white;
+    background-color: $white;
+
+    &--prototype {
+        background-color: $carrot;
+        color: $white;
+    }
+
+    &__wrapper {
+        border-bottom: 1px solid $iron;
+
+        &--prototype {
+            border-bottom: none;
+        }
+    }
 
     &__icon {
         vertical-align: middle;
@@ -13,14 +25,15 @@
     }
 
     &__text-icon {
-        background-color: $ship-grey;
+        background-color: $matisse;
         color: $iron-light;
         font-weight: 700;
         text-transform: uppercase;
         padding: 5px 8px;
         font-size: 16px;
         position: relative;
-        top: -2px;
+        top: 50%;
+        transform: translateY(50%);
 
         @include breakpoint(sm) {
             display: block;
@@ -31,10 +44,11 @@
     }
 
     &__body {
-        display: inline-block;
+        display: flex;
         padding-bottom: $baseline;
         
         @include breakpoint(md) {
+            display: inline-block;
             padding-top: $baseline;
             margin-left: $col;
         }
@@ -51,15 +65,11 @@
         font-size: 16px;
 
         & > a {
-            color: $white;
             text-decoration: underline;
 
             &:focus {
-                background-color: $white;
                 color: $base-text-colour;
             }
         }
     }
-
-       
 }


### PR DESCRIPTION
### What

Updated the banner styling as per handover notes: https://docs.google.com/document/d/13j2BMS0_nz-B5FEZ1hYLgB4w4YxUncnuUfFYKecdFL4/edit

- Banner `background-color` to `$white`
- Added bottom border of `1px solid $iron` to be displayed within an additional `banner__wrapper` class
- Removed CMD breadcrumbs bottom border
- Updated responsive styling so on mobiles the beta icon and text is in a two-column setup instead of one above the other
- Added styling for the prototype banner (currently not in use)

### How to review

- Ensure both beta and service banners align with the handover notes.
- Service message can be added via Florence.
- Beta banner can be found on a CMD/dataset page.

### Who can review

Anyone but me
