### PR TITLE
add banner-container class to manage central alignment of icon

### DIFF
--- a/scss/components/_banner.scss
+++ b/scss/components/_banner.scss
@@ -45,7 +45,6 @@
         @include breakpoint(sm) {
             display: block;
             float: left;
-            margin-top: 8px;
             margin-right: 8px;
             transform: translateY(50%);
         }

--- a/scss/components/_banner.scss
+++ b/scss/components/_banner.scss
@@ -15,6 +15,8 @@
     }
 
     &__container {
+        display: -webkit-box;
+        display: -ms-flexbox;
         display: flex;
         align-items: center;
         margin-left: 16px;

--- a/scss/components/_banner.scss
+++ b/scss/components/_banner.scss
@@ -14,10 +14,18 @@
         border-bottom: none;
     }
 
+    &__container {
+        display: flex;
+        align-items: center;
+        margin-left: 16px;
+        @include breakpoint(sm) {
+            display: block;
+        }
+    }
+
     &__icon {
         vertical-align: middle;
         position: relative;
-        top: -2px;
 
         @include breakpoint(sm) {
             display: none;


### PR DESCRIPTION
### What

Issue: Service message 'i' icon would be displaced and float away in medium sized viewports. The service message banner has subsequently been updated to be a two-column setup rather than one in order to align the icon with the service message in different contexts.

### How to review

Check changes to CSS and review service message banner across various browsers and widths (can be found on the ONS homepage) 

### Who can review

Anyone bar me.
