### PR TITLE
Feature/cookies banner js enhancement

### DIFF
--- a/js/app/cookies-banner.js
+++ b/js/app/cookies-banner.js
@@ -1,7 +1,4 @@
-// enhanced cookie banner needs to:
-// 1. on 'Accept All', send a request to the cookies controller designating that all cookies are to be accepted
-// 2. set cookies_preferences_set=true; cookies_policy={essential: true, usage: true}
-// 3. Success message
+var oneYearInSeconds = 31622400
 
 function initCookiesBanner() {
     $('.js-hide-cookies-banner').click(function(e) {
@@ -14,21 +11,12 @@ function submitCookieForm(e) {
     e.preventDefault();
     $('.js-accept-cookies').prop('disabled')
     $('.js-accept-cookies').addClass("btn--primary-disabled")
-    $.ajax({
-        type: "GET",
-        url: "/cookie/accept-all",
-        error: function (error) {
-            console.log('Error with accepting all cookies:', error.statusText);
-            $('.js-accept-cookies').removeProp('disabled')
-            $('.js-accept-cookies').removeClass("btn--primary-disabled")
-        },
-        success: function(result) {
-            // to update once endpoint is available
-            document.cookie = result.cookies_policy
-            $('.js-cookies-banner-inform').addClass('hidden')
-            $('.js-cookies-banner-confirmation').removeClass('hidden')
-        }
-    });
+
+    document.cookie = "cookies_preferences_set=true; max-age=" + oneYearInSeconds + ";"
+    document.cookie = "cookies_policy=%7B%22essential%22%3Atrue%2C%22usage%22%3Atrue%7D; max-age=" + oneYearInSeconds + ";"
+
+    $('.js-cookies-banner-inform').addClass('hidden')
+    $('.js-cookies-banner-confirmation').removeClass('hidden')
 }
 
 $(function() {

--- a/js/app/cookies-banner.js
+++ b/js/app/cookies-banner.js
@@ -1,0 +1,34 @@
+// enhanced cookie banner needs to:
+// 1. on 'Accept All', send a request to the cookies controller designating that all cookies are to be accepted
+// 2. set cookies_preferences_set=true; cookies_policy={essential: true, usage: true}
+// 3. Success message
+
+function initCookiesBanner() {
+    $('.js-hide-cookies-banner').click(function(e) {
+        $('.js-cookies-banner-form').addClass("hidden");
+    })
+    $(".js-cookies-banner-form").on('submit', submitCookieForm)
+}
+
+function submitCookieForm(e) {
+    e.preventDefault();
+    $('.js-accept-cookies').prop('disabled', 'true')
+    $('.js-accept-cookies').addClass("btn--primary-disabled")
+    $.ajax({
+        type: "GET",
+        url: "/cookies/accept-all",
+        error: function (error) {
+            console.log('Error with accepting all cookies:', error.statusText);
+        },
+        success: function(result) {
+            document.cookie = "cookie_preferences_set=true"
+            document.cookie = result.cookies_policy
+            $('.js-cookies-banner-inform').addClass('hidden')
+            $('.cookies-banner__confirmation').removeClass('hidden')
+        }
+    });
+}
+
+$(function() {
+    initCookiesBanner();
+});

--- a/js/app/cookies-banner.js
+++ b/js/app/cookies-banner.js
@@ -16,7 +16,7 @@ function submitCookieForm(e) {
     $('.js-accept-cookies').addClass("btn--primary-disabled")
     $.ajax({
         type: "GET",
-        url: "/cookies/accept-all",
+        url: "/cookie/accept-all",
         error: function (error) {
             console.log('Error with accepting all cookies:', error.statusText);
             $('.js-accept-cookies').removeProp('disabled')

--- a/js/app/cookies-banner.js
+++ b/js/app/cookies-banner.js
@@ -12,19 +12,21 @@ function initCookiesBanner() {
 
 function submitCookieForm(e) {
     e.preventDefault();
-    $('.js-accept-cookies').prop('disabled', 'true')
+    $('.js-accept-cookies').prop('disabled')
     $('.js-accept-cookies').addClass("btn--primary-disabled")
     $.ajax({
         type: "GET",
         url: "/cookies/accept-all",
         error: function (error) {
             console.log('Error with accepting all cookies:', error.statusText);
+            $('.js-accept-cookies').removeProp('disabled')
+            $('.js-accept-cookies').removeClass("btn--primary-disabled")
         },
         success: function(result) {
-            document.cookie = "cookie_preferences_set=true"
+            // to update once endpoint is available
             document.cookie = result.cookies_policy
             $('.js-cookies-banner-inform').addClass('hidden')
-            $('.cookies-banner__confirmation').removeClass('hidden')
+            $('.js-cookies-banner-confirmation').removeClass('hidden')
         }
     });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4628,9 +4628,9 @@
             "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
         },
         "uglify-js": {
-            "version": "3.7.6",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.6.tgz",
-            "integrity": "sha512-yYqjArOYSxvqeeiYH2VGjZOqq6SVmhxzaPjJC1W2F9e+bqvFL9QXQ2osQuKUFjM2hGjKG2YclQnRKWQSt/nOTQ==",
+            "version": "3.8.0",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.8.0.tgz",
+            "integrity": "sha512-ugNSTT8ierCsDHso2jkBHXYrU8Y5/fY2ZUprfrJUiD7YpuFvV4jODLFmb3h4btQjqr5Nh4TX4XtgDfCU1WdioQ==",
             "requires": {
                 "commander": "~2.20.3",
                 "source-map": "~0.6.1"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "Pattern library for ONS website",
     "main": "",
     "config": {
-        "js": "js/thirdparty/jquery.js js/thirdparty/details.polyfill.js js/thirdparty/doubletaptogo.js js/app.js js/app/display.js  js/app/preview.js js/app/checkboxes.js js/app/viewport-size.js js/app/gtm.js js/app/nav.js js/app/show-and-hide.js js/app/show-more-list.js js/app/sticky-scroll.js js/app/date-picker.js js/app/table-of-contents.js js/app/mobile-filters.js js/app/equal-height.js js/app/print-page.js js/app/hover-state.js js/app/scroll.js js/app/loading-screen.js js/app/date-range-updater.js js/app/filter-options.js js/app/time-selector.js js/app/filter-select.js js/app/improve-this-page.js js/app/embed-code-copy.js"
+        "js": "js/thirdparty/jquery.js js/thirdparty/details.polyfill.js js/thirdparty/doubletaptogo.js js/app.js js/app/cookies-banner.js js/app/display.js  js/app/preview.js js/app/checkboxes.js js/app/viewport-size.js js/app/gtm.js js/app/nav.js js/app/show-and-hide.js js/app/show-more-list.js js/app/sticky-scroll.js js/app/date-picker.js js/app/table-of-contents.js js/app/mobile-filters.js js/app/equal-height.js js/app/print-page.js js/app/hover-state.js js/app/scroll.js js/app/loading-screen.js js/app/date-range-updater.js js/app/filter-options.js js/app/time-selector.js js/app/filter-select.js js/app/improve-this-page.js js/app/embed-code-copy.js"
     },
     "scripts": {
         "clean": "",

--- a/scss/components/_cookies-banner.scss
+++ b/scss/components/_cookies-banner.scss
@@ -57,7 +57,6 @@
             text-decoration: underline;
             color: $matisse;
             padding: 0;
-            margin-top: 10px;
         }
     }
 

--- a/scss/components/_cookies-banner.scss
+++ b/scss/components/_cookies-banner.scss
@@ -44,6 +44,21 @@
             width: 100%;
             display: block;
         }
+
+        &--hide {
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+            font-weight: 400;
+            font-size: 14px;
+            line-height: 1.25;
+            outline: 0;
+            border: 0;
+            background: none;
+            text-decoration: underline;
+            color: $matisse;
+            padding: 0;
+            margin-top: 10px;
+        }
     }
 
     a {

--- a/scss/components/_cookies-banner.scss
+++ b/scss/components/_cookies-banner.scss
@@ -49,7 +49,7 @@
             -webkit-font-smoothing: antialiased;
             -moz-osx-font-smoothing: grayscale;
             font-weight: 400;
-            font-size: 14px;
+            font-size: 18px;
             line-height: 1.25;
             outline: 0;
             border: 0;
@@ -57,6 +57,13 @@
             text-decoration: underline;
             color: $matisse;
             padding: 0;
+            float: right;
+
+            @include breakpoint(md-max) {
+                padding: 1rem 0;
+                display: block;
+                float: none;
+            }
         }
     }
 


### PR DESCRIPTION
### What

- Added JS functionality to cookies banner:
    - JS enhancement to remove request to server
    - Set `set_cookies_preferences` and `cookies_policy` client-side
    - Display success banner upon clicking "Accept all" to confirm that preferences have been set
    - JS functionality to hide the banner once cookies have been set
- Updated styling for 'Hide' button 
    - font size increased to align with increased font sizes across the banner. This fix is pending in another PR so may not be present. If you want to view the banner with the font size tweaks you can do so on the `fix/cookie-banner-font-size` branches on `dp-frontend-renderer` and `babbage`
    - Hide button floats right on larger viewports and is block-level on smaller viewports - aligning with gov UK pattern

### How to review

- Pull changes and go through steps to render cookie banners.

**Babbage served pages**
- You can set `export ENABLE_COOKIES_CONTROL` to `true` in either of the `run` scripts

**Frontend Renderer served pages**
- Run `dp-frontend-router` with `COOKIES_ROUTES_ENABLED=true` and `DATASET_ROUTES_ENABLED=true` to have access to CMD pages
- Run `dp-frontend-dataset-controller` with `ENABLE_COOKIES_CONTROL=true`
- Run `dp-frontend-cookies-controller`

- Check that behaviour of the js enhanced banner is as intended, that is to say, the 'Accept all' button triggers the local setting of the cookies, displays the success banner, and the 'Hide' button hides the banner

- Check success banner styles align across browsers (have already checked in Browserstack and across various browsers, but worth a second pair of eyes)

### Who can review

Anyone bar me
