### PR TITLE
Feature/cookies preferences success

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4628,9 +4628,9 @@
             "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
         },
         "uglify-js": {
-            "version": "3.7.6",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.6.tgz",
-            "integrity": "sha512-yYqjArOYSxvqeeiYH2VGjZOqq6SVmhxzaPjJC1W2F9e+bqvFL9QXQ2osQuKUFjM2hGjKG2YclQnRKWQSt/nOTQ==",
+            "version": "3.8.0",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.8.0.tgz",
+            "integrity": "sha512-ugNSTT8ierCsDHso2jkBHXYrU8Y5/fY2ZUprfrJUiD7YpuFvV4jODLFmb3h4btQjqr5Nh4TX4XtgDfCU1WdioQ==",
             "requires": {
                 "commander": "~2.20.3",
                 "source-map": "~0.6.1"

--- a/scss/components/_cookies-banner.scss
+++ b/scss/components/_cookies-banner.scss
@@ -71,7 +71,7 @@
 
     &__preferences-success {
         display: block;
-        border-left: 7px solid $salem;
+        border-left: $baseline solid $salem;
         background: $lily-white;
     }
 
@@ -79,6 +79,6 @@
         display: flex;
         flex-direction: column;
         justify-content: center;
-        padding: 8px 0 8px 16px;
+        padding: $baseline 0 $baseline $col;
     }
 }

--- a/scss/components/_cookies-banner.scss
+++ b/scss/components/_cookies-banner.scss
@@ -71,7 +71,7 @@
 
     &__preferences-success {
         display: block;
-        border-left: 7px solid #0F8243;
+        border-left: 7px solid $salem;
         background: #cfe6d9;
     }
 
@@ -79,7 +79,7 @@
         display: flex;
         flex-direction: column;
         justify-content: center;
-        padding-left: 1.5rem;
+        padding: 8px 0 8px 16px;
 
         h2 {
             margin-top: 20px;

--- a/scss/components/_cookies-banner.scss
+++ b/scss/components/_cookies-banner.scss
@@ -80,13 +80,5 @@
         flex-direction: column;
         justify-content: center;
         padding: 8px 0 8px 16px;
-
-        h2 {
-            margin-top: 20px;
-        }
-
-        p {
-            margin: 8px 0;
-        }
     }
 }

--- a/scss/components/_cookies-banner.scss
+++ b/scss/components/_cookies-banner.scss
@@ -72,7 +72,7 @@
     &__preferences-success {
         display: block;
         border-left: 7px solid $salem;
-        background: $salem-success;
+        background: $lily-white;
     }
 
     &__preferences-success-body {

--- a/scss/components/_cookies-banner.scss
+++ b/scss/components/_cookies-banner.scss
@@ -72,7 +72,7 @@
     &__preferences-success {
         display: block;
         border-left: 7px solid $salem;
-        background: #cfe6d9;
+        background: $salem-success;
     }
 
     &__preferences-success-body {

--- a/scss/components/_cookies-banner.scss
+++ b/scss/components/_cookies-banner.scss
@@ -71,7 +71,7 @@
 
     &__preferences-success {
         display: block;
-        border-left: $baseline solid $salem;
+        border-left: 8px solid $salem;
         background: $lily-white;
     }
 

--- a/scss/components/_cookies-banner.scss
+++ b/scss/components/_cookies-banner.scss
@@ -68,4 +68,25 @@
         padding: 0;
         margin: 8px 0;
     }
+
+    &__preferences-success {
+        display: block;
+        border-left: 7px solid #0F8243;
+        background: #cfe6d9;
+    }
+
+    &__preferences-success-body {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        padding-left: 1.5rem;
+
+        h2 {
+            margin-top: 20px;
+        }
+
+        p {
+            margin: 8px 0;
+        }
+    }
 }

--- a/scss/utilities/_colours.scss
+++ b/scss/utilities/_colours.scss
@@ -22,6 +22,7 @@ $cod-gray:	    #111111;
 $matisse: 		#206095; //links
 $blumine:       #1A4C76; //hover links
 $salem:			#0F8243; //active links
+$salem-success: #edf4f0; //success bg colour
 $poppy:         #D32F2F; //errors
 $carrot:		#FF9933; //beta content
 $astral:		#3B7A9E;

--- a/scss/utilities/_colours.scss
+++ b/scss/utilities/_colours.scss
@@ -22,7 +22,7 @@ $cod-gray:	    #111111;
 $matisse: 		#206095; //links
 $blumine:       #1A4C76; //hover links
 $salem:			#0F8243; //active links
-$salem-success: #edf4f0; //success bg colour
+$lily-white:    #edf4f0; //success bg colour
 $poppy:         #D32F2F; //errors
 $carrot:		#FF9933; //beta content
 $astral:		#3B7A9E;


### PR DESCRIPTION
### What

- Add styling for cookies preference form success message
- Add `salem-success` - background colour tint for `salem` colour based on [ONS design system](https://ons-design-system.netlify.com/styles/colours/)

### How to review

- Ensure style updates are logical
- Check styling - should be able to view the banner if you update your cookies preferences on `/cookies`

### Who can review

Anyone but me
