### PR TITLE
update cookies domain

### DIFF
--- a/js/app/cookies-banner.js
+++ b/js/app/cookies-banner.js
@@ -1,4 +1,7 @@
+// cookies settings
 var oneYearInSeconds = 31622400
+var url = window.location.hostname
+var cookiesDomain = extractDomainFromUrl(url)
 
 function initCookiesBanner() {
     $('.js-hide-cookies-banner').click(function(e) {
@@ -12,11 +15,25 @@ function submitCookieForm(e) {
     $('.js-accept-cookies').prop('disabled')
     $('.js-accept-cookies').addClass("btn--primary-disabled")
 
-    document.cookie = "cookies_preferences_set=true; max-age=" + oneYearInSeconds + ";"
-    document.cookie = "cookies_policy=%7B%22essential%22%3Atrue%2C%22usage%22%3Atrue%7D; max-age=" + oneYearInSeconds + ";"
+    document.cookie = "cookies_preferences_set=true; max-age=" + oneYearInSeconds + ";" + "domain=" + cookiesDomain + ";"
+    document.cookie = "cookies_policy=%7B%22essential%22%3Atrue%2C%22usage%22%3Atrue%7D; max-age=" + oneYearInSeconds + ";" + "domain=" + cookiesDomain + ";"
 
     $('.js-cookies-banner-inform').addClass('hidden')
     $('.js-cookies-banner-confirmation').removeClass('hidden')
+}
+
+function extractDomainFromUrl(url) {
+    if (url.includes('localhost')) {
+        return 'localhost'
+    }
+
+    // top level domains (TLD/SLD) in use
+    var tlds = new RegExp('(.co.uk|.gov.uk)')
+
+    var topLevelDomain = url.match(tlds)[0]
+    var secondLevelDomain = url.replace(topLevelDomain, '').split('.').pop()
+
+    return "." + secondLevelDomain + "." + topLevelDomain
 }
 
 $(function() {

--- a/js/app/cookies-banner.js
+++ b/js/app/cookies-banner.js
@@ -2,6 +2,8 @@
 var oneYearInSeconds = 31622400;
 var url = window.location.hostname;
 var cookiesDomain = extractDomainFromUrl(url);
+var cookiesPreference = true;
+var encodedCookiesPolicy = "%7B%22essential%22%3Atrue%2C%22usage%22%3Atrue%7D";
 
 function initCookiesBanner() {
     $('.js-hide-cookies-banner').click(function(e) {
@@ -12,11 +14,13 @@ function initCookiesBanner() {
 
 function submitCookieForm(e) {
     e.preventDefault();
-    $('.js-accept-cookies').prop('disabled')
-        .addClass("btn--primary-disabled");
+    var cookiesBanner = $('.js-accept-cookies');
+    
+    cookiesBanner.prop('disabled')
+    cookiesBanner.addClass("btn--primary-disabled");
 
-    document.cookie = "cookies_preferences_set=true; max-age=" + oneYearInSeconds + ";" + "domain=" + cookiesDomain + ";";
-    document.cookie = "cookies_policy=%7B%22essential%22%3Atrue%2C%22usage%22%3Atrue%7D; max-age=" + oneYearInSeconds + ";" + "domain=" + cookiesDomain + ";";
+    document.cookie = "cookies_preferences_set=" + cookiesPreference + ";" + "max-age=" + oneYearInSeconds + ";" + "domain=" + cookiesDomain + ";";
+    document.cookie = "cookies_policy=" + encodedCookiesPolicy + ";" + "max-age=" + oneYearInSeconds + ";" + "domain=" + cookiesDomain + ";";
 
     $('.js-cookies-banner-inform').addClass('hidden');
     $('.js-cookies-banner-confirmation').removeClass('hidden');


### PR DESCRIPTION
### What

- Update cookies domain to be prefixed with a `.` so that the cookie is included in all subdomains
- This will also mean that accepting cookies on the English language version of the site and then switching to Welsh - or vice versa - will no longer mean the cookies banner re-appears.

### How to review

- Check that the code looks okay
- Currently top level domains are included in the functions to be able to extract the second level domain. May be a question of whether we want this exposed or not
- The domain testing won't be possible locally, and can only be checked on develop. You could test the function itself in browser console and see that it returns the intended domain, though

### Who can review

Anyone but me