### PR TITLE
Added a hidden message for cookies preg

### DIFF
--- a/js/app/cookies-banner.js
+++ b/js/app/cookies-banner.js
@@ -1,22 +1,22 @@
-var oneYearInSeconds = 31622400
+var oneYearInSeconds = 31622400;
 
 function initCookiesBanner() {
     $('.js-hide-cookies-banner').click(function(e) {
         $('.js-cookies-banner-form').addClass("hidden");
-    })
+    });
     $(".js-cookies-banner-form").on('submit', submitCookieForm)
 }
 
 function submitCookieForm(e) {
     e.preventDefault();
     $('.js-accept-cookies').prop('disabled')
-    $('.js-accept-cookies').addClass("btn--primary-disabled")
+        .addClass("btn--primary-disabled");
 
-    document.cookie = "cookies_preferences_set=true; max-age=" + oneYearInSeconds + ";"
-    document.cookie = "cookies_policy=%7B%22essential%22%3Atrue%2C%22usage%22%3Atrue%7D; max-age=" + oneYearInSeconds + ";"
+    document.cookie = "cookies_preferences_set=true; max-age=" + oneYearInSeconds + ";";
+    document.cookie = "cookies_policy=%7B%22essential%22%3Atrue%2C%22usage%22%3Atrue%7D; max-age=" + oneYearInSeconds + ";";
 
-    $('.js-cookies-banner-inform').addClass('hidden')
-    $('.js-cookies-banner-confirmation').removeClass('hidden')
+    $('.js-cookies-banner-inform').addClass('hidden');
+    $('.js-cookies-banner-confirmation').removeClass('hidden');
 }
 
 $(function() {

--- a/js/app/cookies-pref.js
+++ b/js/app/cookies-pref.js
@@ -1,0 +1,7 @@
+$(function() {
+    if($("#cookies-no-js").length > 0) {
+        $("#cookies-no-js").addClass('hidden');
+    }
+});
+
+

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "Pattern library for ONS website",
     "main": "",
     "config": {
-        "js": "js/thirdparty/jquery.js js/thirdparty/details.polyfill.js js/thirdparty/doubletaptogo.js js/app.js js/app/cookies-banner.js js/app/display.js  js/app/preview.js js/app/checkboxes.js js/app/viewport-size.js js/app/gtm.js js/app/nav.js js/app/show-and-hide.js js/app/show-more-list.js js/app/sticky-scroll.js js/app/date-picker.js js/app/table-of-contents.js js/app/mobile-filters.js js/app/equal-height.js js/app/print-page.js js/app/hover-state.js js/app/scroll.js js/app/loading-screen.js js/app/date-range-updater.js js/app/filter-options.js js/app/time-selector.js js/app/filter-select.js js/app/improve-this-page.js js/app/embed-code-copy.js"
+        "js": "js/thirdparty/jquery.js js/thirdparty/details.polyfill.js js/thirdparty/doubletaptogo.js js/app.js js/app/cookies-banner.js js/app/cookies-pref.js js/app/display.js  js/app/preview.js js/app/checkboxes.js js/app/viewport-size.js js/app/gtm.js js/app/nav.js js/app/show-and-hide.js js/app/show-more-list.js js/app/sticky-scroll.js js/app/date-picker.js js/app/table-of-contents.js js/app/mobile-filters.js js/app/equal-height.js js/app/print-page.js js/app/hover-state.js js/app/scroll.js js/app/loading-screen.js js/app/date-range-updater.js js/app/filter-options.js js/app/time-selector.js js/app/filter-select.js js/app/improve-this-page.js js/app/embed-code-copy.js"
     },
     "scripts": {
         "clean": "",


### PR DESCRIPTION
### What

On Cookies preferences page we now show a message saying that JS is not enabled thus you can't change your cookie preferences.

- This is the addition of the new function to handle hiding this message if JS is enabled
- Also added chaining for the cookies banner js-accept-cookies, as getting the element twice is slower than getting it once and manipulating it twice straight away.
- Added explicit end of the statement `;`

### How to review

Check the JS

### Who can review

Anyone except me
