### PR TITLE
Cookies preferences page updated with a no Js version

### DIFF
--- a/js/app/cookies-pref.js
+++ b/js/app/cookies-pref.js
@@ -1,6 +1,9 @@
-$(function() {
-    if($("#cookies-no-js").length > 0) {
-        $("#cookies-no-js").addClass('hidden');
+$(function () {
+    if ($(".cookies-no-js").length > 0) {
+        $(".cookies-no-js").addClass('hidden');
+    }
+    if ($(".cookies-js").length > 0) {
+            $(".cookies-js").removeClass('hidden');
     }
 });
 


### PR DESCRIPTION
### What

- Cookies pref page
- Make items on the cookies pref page visible or hidden, depending on if JS enabled or disabled

### How to review

- Use the renderer PR in conjunction with this and go to the cookies preferences page.
https://github.com/ONSdigital/dp-frontend-renderer/pull/356
- Turn JS off and the page usage section, save all button and

### Who can review

Anyone except me
