### PR TITLE
explicitly set path to '/' so all site pages are covered by the cookies

### DIFF
--- a/js/app/cookies-banner.js
+++ b/js/app/cookies-banner.js
@@ -4,6 +4,7 @@ var url = window.location.hostname;
 var cookiesDomain = extractDomainFromUrl(url);
 var cookiesPreference = true;
 var encodedCookiesPolicy = "%7B%22essential%22%3Atrue%2C%22usage%22%3Atrue%7D";
+var cookiesPath = "/";
 
 function initCookiesBanner() {
     $('.js-hide-cookies-banner').click(function(e) {
@@ -19,8 +20,8 @@ function submitCookieForm(e) {
     cookiesBanner.prop('disabled')
     cookiesBanner.addClass("btn--primary-disabled");
 
-    document.cookie = "cookies_preferences_set=" + cookiesPreference + ";" + "max-age=" + oneYearInSeconds + ";" + "domain=" + cookiesDomain + ";";
-    document.cookie = "cookies_policy=" + encodedCookiesPolicy + ";" + "max-age=" + oneYearInSeconds + ";" + "domain=" + cookiesDomain + ";";
+    document.cookie = "cookies_preferences_set=" + cookiesPreference + ";" + "max-age=" + oneYearInSeconds + ";" + "domain=" + cookiesDomain + ";" + "path=" + cookiesPath + ";";
+    document.cookie = "cookies_policy=" + encodedCookiesPolicy + ";" + "max-age=" + oneYearInSeconds + ";" + "domain=" + cookiesDomain + ";" + "path=" + cookiesPath + ";";
 
     $('.js-cookies-banner-inform').addClass('hidden');
     $('.js-cookies-banner-confirmation').removeClass('hidden');


### PR DESCRIPTION
### What

Explicitly set cookies `path` to `/` so that it overrides the JS default of setting it based on current path.

### How to review

- Accept cookies on a page that includes a deep path such as `/datasets/cpih01/editions/time-series/versions`
- Ensure that the cookies set have a path of `/`
- Ensure that, upon navigating to another page, such as the homepage, the cookies banner is not displayed

### Who can review

Anyone but me