### PR TITLE
remove . for top level domain as that's extracted from regex

### DIFF
--- a/js/app/cookies-banner.js
+++ b/js/app/cookies-banner.js
@@ -2,6 +2,7 @@
 var oneYearInSeconds = 31622400;
 var url = window.location.hostname;
 var cookiesDomain = extractDomainFromUrl(url);
+console.log(cookiesDomain);
 var cookiesPreference = true;
 var encodedCookiesPolicy = "%7B%22essential%22%3Atrue%2C%22usage%22%3Atrue%7D";
 var cookiesPath = "/";
@@ -38,7 +39,7 @@ function extractDomainFromUrl(url) {
     var topLevelDomain = url.match(tlds)[0];
     var secondLevelDomain = url.replace(topLevelDomain, '').split('.').pop();
 
-    return "." + secondLevelDomain + "." + topLevelDomain;
+    return "." + secondLevelDomain + topLevelDomain;
 }
 
 $(function() {

--- a/js/app/cookies-banner.js
+++ b/js/app/cookies-banner.js
@@ -2,7 +2,6 @@
 var oneYearInSeconds = 31622400;
 var url = window.location.hostname;
 var cookiesDomain = extractDomainFromUrl(url);
-console.log(cookiesDomain);
 var cookiesPreference = true;
 var encodedCookiesPolicy = "%7B%22essential%22%3Atrue%2C%22usage%22%3Atrue%7D";
 var cookiesPath = "/";


### PR DESCRIPTION
### What

Remove superfluous `.` from the domain builder function as the top level domain extracted from the URL already contains a `.`.

### How to review

Ensure return statement does not include a `.` between the second and top level domains

### Who can review

Anyone but me
