### PR TITLE
Feature/client side banner rendering

### DIFF
--- a/js/app/cookies-banner.js
+++ b/js/app/cookies-banner.js
@@ -9,7 +9,7 @@ var cookiesPreference = true;
 var encodedCookiesPolicy = "%7B%22essential%22%3Atrue%2C%22usage%22%3Atrue%7D";
 var cookiesPath = "/";
 
-document.addEventListener("DOMContentLoaded", determineWhetherToRenderBanner())
+document.addEventListener("DOMContentLoaded", determineWhetherToRenderBanner());
 
 function determineWhetherToRenderBanner() {
     if (cookiesSet) {
@@ -20,17 +20,17 @@ function determineWhetherToRenderBanner() {
 }
 
 function initCookiesBanner() {
-    $('.js-hide-cookies-banner').click(function(e) {
+    $('.js-hide-cookies-banner').click(function (e) {
         cookiesBanner.addClass("hidden");
     });
-    cookiesBanner.on('submit', submitCookieForm)
+    cookiesBanner.on('submit', submitCookieForm);
 }
 
 function submitCookieForm(e) {
     e.preventDefault();
     var cookiesAcceptBanner = $('.js-accept-cookies');
-    
-    cookiesAcceptBanner.prop('disabled')
+
+    cookiesAcceptBanner.prop('disabled');
     cookiesAcceptBanner.addClass("btn--primary-disabled");
 
     document.cookie = "cookies_preferences_set=" + cookiesPreference + ";" + "max-age=" + oneYearInSeconds + ";" + "domain=" + cookiesDomain + ";" + "path=" + cookiesPath + ";";
@@ -55,5 +55,5 @@ function extractDomainFromUrl(url) {
 }
 
 function hasCookiesPreferencesSet() {
-    return document.cookie.indexOf("cookies_preferences_set=true") > -1
+    return document.cookie.indexOf("cookies_preferences_set=true") > -1;
 }

--- a/js/app/cookies-banner.js
+++ b/js/app/cookies-banner.js
@@ -1,3 +1,6 @@
+// get preferences cookie
+var cookiesSet = hasCookiesPreferencesSet()
+
 // cookies settings
 var oneYearInSeconds = 31622400;
 var url = window.location.hostname;
@@ -5,20 +8,32 @@ var cookiesDomain = extractDomainFromUrl(url);
 var cookiesPreference = true;
 var encodedCookiesPolicy = "%7B%22essential%22%3Atrue%2C%22usage%22%3Atrue%7D";
 var cookiesPath = "/";
+var cookiesBanner = $(".js-cookies-banner-form");
+
+document.addEventListener("DOMContentLoaded", determineWhetherToRenderBanner())
+
+function determineWhetherToRenderBanner() {
+    cookiesBanner.addClass("hidden");
+
+    if (!cookiesSet) {
+        cookiesBanner.removeClass("hidden");
+        initCookiesBanner();
+    }
+}
 
 function initCookiesBanner() {
     $('.js-hide-cookies-banner').click(function(e) {
-        $('.js-cookies-banner-form').addClass("hidden");
+        cookiesBanner.addClass("hidden");
     });
-    $(".js-cookies-banner-form").on('submit', submitCookieForm)
+    cookiesBanner.on('submit', submitCookieForm)
 }
 
 function submitCookieForm(e) {
     e.preventDefault();
-    var cookiesBanner = $('.js-accept-cookies');
+    var cookiesAcceptBanner = $('.js-accept-cookies');
     
-    cookiesBanner.prop('disabled')
-    cookiesBanner.addClass("btn--primary-disabled");
+    cookiesAcceptBanner.prop('disabled')
+    cookiesAcceptBanner.addClass("btn--primary-disabled");
 
     document.cookie = "cookies_preferences_set=" + cookiesPreference + ";" + "max-age=" + oneYearInSeconds + ";" + "domain=" + cookiesDomain + ";" + "path=" + cookiesPath + ";";
     document.cookie = "cookies_policy=" + encodedCookiesPolicy + ";" + "max-age=" + oneYearInSeconds + ";" + "domain=" + cookiesDomain + ";" + "path=" + cookiesPath + ";";
@@ -41,6 +56,17 @@ function extractDomainFromUrl(url) {
     return "." + secondLevelDomain + topLevelDomain;
 }
 
-$(function() {
-    initCookiesBanner();
-});
+function hasCookiesPreferencesSet() {
+    var cookies = document.cookie.split(";");
+
+    cookies = cookies.map(function (el) {
+        return el.trim();
+    });
+
+    for (var i = 0; i < cookies.length; i++) {
+        if (cookies[i] === "cookies_preferences_set=true") {
+            return true;
+        }
+    }
+    return false;
+}

--- a/js/app/cookies-banner.js
+++ b/js/app/cookies-banner.js
@@ -43,7 +43,7 @@ function submitCookieForm(e) {
 }
 
 function extractDomainFromUrl(url) {
-    if (url.includes('localhost')) {
+    if (url.indexOf('localhost') >= 0) {
         return 'localhost';
     }
 

--- a/js/app/cookies-banner.js
+++ b/js/app/cookies-banner.js
@@ -1,22 +1,20 @@
-// get preferences cookie
-var cookiesSet = hasCookiesPreferencesSet()
-
 // cookies settings
+var cookiesSet = hasCookiesPreferencesSet();
+var cookiesBanner = $(".js-cookies-banner-form");
+
 var oneYearInSeconds = 31622400;
 var url = window.location.hostname;
 var cookiesDomain = extractDomainFromUrl(url);
 var cookiesPreference = true;
 var encodedCookiesPolicy = "%7B%22essential%22%3Atrue%2C%22usage%22%3Atrue%7D";
 var cookiesPath = "/";
-var cookiesBanner = $(".js-cookies-banner-form");
 
 document.addEventListener("DOMContentLoaded", determineWhetherToRenderBanner())
 
 function determineWhetherToRenderBanner() {
-    cookiesBanner.addClass("hidden");
-
-    if (!cookiesSet) {
-        cookiesBanner.removeClass("hidden");
+    if (cookiesSet) {
+        cookiesBanner.addClass("hidden");
+    } else {
         initCookiesBanner();
     }
 }
@@ -57,16 +55,5 @@ function extractDomainFromUrl(url) {
 }
 
 function hasCookiesPreferencesSet() {
-    var cookies = document.cookie.split(";");
-
-    cookies = cookies.map(function (el) {
-        return el.trim();
-    });
-
-    for (var i = 0; i < cookies.length; i++) {
-        if (cookies[i] === "cookies_preferences_set=true") {
-            return true;
-        }
-    }
-    return false;
+    return document.cookie.indexOf("cookies_preferences_set=true") > -1
 }


### PR DESCRIPTION
### What

Updated the logic in the cookies banner js file so that the conditional rendering of the component can occur client-side.

This means that the banner is always visible by default (non-js journey), and we toggle it visible/invisible client-side depending on whether or not `cookies_preferences_set=true`

### How to review

- Pull `dp-frontend-renderer` and `babbage` branches to test this locally - `feature/no-js-cookies-banner`
- Check to see that banner is not present when `cookies_preferences_set=true` and that it is visible when no cookies have been set.
- Also check that the banner does not flash up and then disappear when first loading a page with cookies preferences set. I've tested this locally and with network throttling on via Google dev tools, and did not see any banner flashing.

### Who can review

Anyone but me
