### PR TITLE
add no-border modifier for meta item

### DIFF
--- a/scss/components/_meta.scss
+++ b/scss/components/_meta.scss
@@ -50,7 +50,7 @@
 		}
 
 		&--no-border {
-			border-right: none;
+			border: none;
 		}
 	}
 

--- a/scss/components/_meta.scss
+++ b/scss/components/_meta.scss
@@ -48,6 +48,10 @@
 		@include breakpoint(lg) {
 			border-right: 1px solid $iron;
 		}
+
+		&--no-border {
+			border-right: none;
+		}
 	}
 
 	&__image {


### PR DESCRIPTION
### What

Added a modifier class, `meta__item--no-border`. This removes the `border-right` property. The reason for this is that the help pages will now have a "Last updated" row within the info header that is stylistically similar to the dataset landing pages pages, but lacks the border

### How to review

Check that the border is removed on help/about pages. You will need to run the Babbage branch, `feature/add-last-updated-static-pages`

### Who can review

Anyone but me
