### PR TITLE
fixed cookies banner rendering on preferences page

### DIFF
--- a/js/app/cookies-banner.js
+++ b/js/app/cookies-banner.js
@@ -12,7 +12,7 @@ var cookiesPath = "/";
 document.addEventListener("DOMContentLoaded", determineWhetherToRenderBanner());
 
 function determineWhetherToRenderBanner() {
-    if (cookiesSet) {
+    if (cookiesSet || userIsOnCookiesPreferencesPage()) {
         cookiesBanner.addClass("hidden");
     } else {
         initCookiesBanner();
@@ -56,4 +56,12 @@ function extractDomainFromUrl(url) {
 
 function hasCookiesPreferencesSet() {
     return document.cookie.indexOf("cookies_preferences_set=true") > -1;
+}
+
+function userIsOnCookiesPreferencesPage() {
+    var href = window.location.href.split("/")
+
+    // check that last element in href array is 'cookies' - in case we add further pages within the cookies path
+    var isCookiesPreferencesPage = href[href.length - 1] === "cookies"
+    return isCookiesPreferencesPage
 }


### PR DESCRIPTION
### What

Fixed bug where cookies banner was rendering on cookies preferences page.

### How to review

- Check code makes sense
- Navigate to `/cookies` and check that the banner is not rendered. Worth checking this with/without `cookies_preferences_set` and `cookies_policy` set in your cookies

### Who can review

Anyone but me
