### PR TITLE
add colours from new colour palette

### DIFF
--- a/scss/main.scss
+++ b/scss/main.scss
@@ -2,6 +2,8 @@
 
 $old-ie: false;
 
+@import "v2/utilities/colour-palette";
+
 @import "utilities/colours";
 @import "utilities/reset";
 @import "utilities/breakpoints";
@@ -74,5 +76,6 @@ $old-ie: false;
 @import "components/improve-this-page";
 @import "components/form";
 @import "components/embed-code";
+
 
 @import "shame";

--- a/scss/old-ie.scss
+++ b/scss/old-ie.scss
@@ -2,6 +2,8 @@
 
 $old-ie: true;
 
+@import "v2/utilities/colour-palette";
+
 @import "utilities/colours";
 @import "utilities/reset";
 @import "utilities/breakpoints";

--- a/scss/v2/utilities/_colour-palette.scss
+++ b/scss/v2/utilities/_colour-palette.scss
@@ -1,0 +1,25 @@
+// ONS Palette
+$spring-green: #A8BD3A;
+$mint-green: #00A3A6;
+$sky-blue: #27A0CC;
+$ocean-blue: #206095;
+$night-blue: #003C57;
+
+// Mono
+$black: #222222;
+$grey1: #414042;
+$grey2: #707071;
+$grey4: #E2E2E3;
+$grey5: #F5F5F6;
+
+// Supporting Palette
+$ruby-red: #D0021B;
+$jaffa-orange: #FE781F;
+$sun-yellow: #FBC900;
+$neon-yellow: #F0F762;
+$leaf-green: #0F8243;
+
+// Census
+$indigo-blue: #3C388E;
+$plum-purple: #902082;
+$flamingo-pink: #DF0667;


### PR DESCRIPTION
### What

Added a new directory and partial, `scss/v2/utilities/_colour-palette` that houses all of the colours and their names for the new ONS design language

### How to review

Check that all colours have been included and have the correct hex code as per the colour palettes document

### Who can review

Anyone but me
