### PR TITLE
Homepage promotional tiles styling

### DIFF
--- a/scss/main.scss
+++ b/scss/main.scss
@@ -74,5 +74,6 @@ $old-ie: false;
 @import "components/improve-this-page";
 @import "components/form";
 @import "components/embed-code";
+@import "v2/components/promo";
 
 @import "shame";

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -2,6 +2,9 @@
 
 $old-ie: false;
 
+
+@import "v2/components/promo";
+
 @import "utilities/colours";
 @import "utilities/reset";
 @import "utilities/breakpoints";
@@ -74,6 +77,5 @@ $old-ie: false;
 @import "components/improve-this-page";
 @import "components/form";
 @import "components/embed-code";
-@import "v2/components/promo";
 
 @import "shame";

--- a/scss/old-ie.scss
+++ b/scss/old-ie.scss
@@ -2,6 +2,9 @@
 
 $old-ie: true;
 
+
+@import "v2/components/promo";
+
 @import "utilities/colours";
 @import "utilities/reset";
 @import "utilities/breakpoints";

--- a/scss/utilities/_colours.scss
+++ b/scss/utilities/_colours.scss
@@ -41,6 +41,11 @@ $disabled:      $iron;
 $census:		$indigo;
 $error:         $poppy;
 
+// v2 Colour Palette
+$flamingo-pink: #DF0667;
+$plum-purple: #902082;
+$night-blue: #003C57;
+$ocean-blue: #206095;
 
 $colours: (
 		//name      			//background-colour 	//font-colour	//anchor-colour

--- a/scss/utilities/_grid.scss
+++ b/scss/utilities/_grid.scss
@@ -115,6 +115,10 @@ $medium-cols-three-quarters: (($medium-complex-grid-cols - 1) * $col) - $medium-
 		padding: 0;
 	}
 
+	&--no-padding {
+		padding: 0;
+	}
+
 
 }
 

--- a/scss/utilities/_grid.scss
+++ b/scss/utilities/_grid.scss
@@ -114,12 +114,6 @@ $medium-cols-three-quarters: (($medium-complex-grid-cols - 1) * $col) - $medium-
 		width: ($large);
 		padding: 0;
 	}
-
-	&--no-padding {
-		padding: 0;
-	}
-
-
 }
 
 

--- a/scss/v2/components/_promo.scss
+++ b/scss/v2/components/_promo.scss
@@ -5,6 +5,7 @@
         &:focus {
             outline: 2px solid $pineapple-yellow;
             outline-offset: 2px;
+            text-decoration: none;
         }
 
         &:hover {

--- a/scss/v2/components/_promo.scss
+++ b/scss/v2/components/_promo.scss
@@ -13,52 +13,6 @@
         }
     }
 
-    &__heading {
-        @include breakpoint(sm) {
-            font-size: 18px;
-            line-height: 1.78;
-        }
-
-        @include breakpoint(md) {
-            font-size: 24px;
-            line-height: 1.78;
-        }
-
-        @include breakpoint(lg) {
-            font-size: 30px;
-            line-height: 1.33;
-            letter-spacing: -0.02px;
-        }
-
-        font-weight: bold;
-        font-stretch: normal;
-        font-style: normal;
-        line-height: 1.33;
-    }
-
-    &__description {
-        width: 100%;
-        word-wrap: break-word;
-        overflow-wrap: break-word;
-        font-size: 18px;
-        font-weight: normal;
-        font-stretch: normal;
-        font-style: normal;
-        line-height: 1.22;
-        letter-spacing: -0.13px;
-        color: #ffffff;
-
-        @include breakpoint(sm) {
-            font-size: 16px;
-            line-height: normal;
-        }
-
-        @include breakpoint(md) {
-            font-size: 16px;
-            line-height: normal;
-        }
-    }
-
     &__background {
         &--blue-gradient {
             background-image: linear-gradient(to bottom, $night-blue, $ocean-blue);
@@ -102,6 +56,52 @@
         
         @include breakpoint(lg) {
             flex-basis: auto;
+        }
+    }
+
+    &__heading {
+        @include breakpoint(sm) {
+            font-size: 18px;
+            line-height: 1.78;
+        }
+
+        @include breakpoint(md) {
+            font-size: 24px;
+            line-height: 1.78;
+        }
+
+        @include breakpoint(lg) {
+            font-size: 30px;
+            line-height: 1.33;
+            letter-spacing: -0.02px;
+        }
+
+        font-weight: bold;
+        font-stretch: normal;
+        font-style: normal;
+        line-height: 1.33;
+    }
+
+    &__description {
+        width: 100%;
+        word-wrap: break-word;
+        overflow-wrap: break-word;
+        font-size: 18px;
+        font-weight: normal;
+        font-stretch: normal;
+        font-style: normal;
+        line-height: 1.22;
+        letter-spacing: -0.13px;
+        color: #ffffff;
+
+        @include breakpoint(sm) {
+            font-size: 16px;
+            line-height: normal;
+        }
+
+        @include breakpoint(md) {
+            font-size: 16px;
+            line-height: normal;
         }
     }
 }

--- a/scss/v2/components/_promo.scss
+++ b/scss/v2/components/_promo.scss
@@ -25,9 +25,17 @@
             font-size: 18px;
             line-height: 1.78;
         }
+
+        @include breakpoint(md) {
+            font-size: 18px;
+            line-height: 1.78;
+        }
     }
 
     &__description {
+        width: 100%;
+        word-wrap: break-word;
+        overflow-wrap: break-word;
         font-size: 18px;
         font-weight: normal;
         font-stretch: normal;
@@ -40,6 +48,11 @@
             font-size: 16px;
             line-height: normal;
         }
+
+        @include breakpoint(md) {
+            font-size: 16px;
+            line-height: normal;
+        }
     }
 
     &__background {
@@ -49,16 +62,22 @@
         }
 
         &--plum-gradient {
-            background-image: linear-gradient(to bottom, $plum-purple, $flamingo-pink);
+            background-image: linear-gradient(to right, $indigo-blue, $plum-purple);
             color: $white;
         }
     }
 
     &__body {
         display: flex;
-        justify-content: space-evenly;
         height: 100%;
         align-items: center;
+        justify-content: space-between;
+
+        &:before,
+        &:after {
+          content: '';
+          display: block;
+        }
 
         &--column {
             display: flex;
@@ -75,6 +94,10 @@
     &__content {
         @include breakpoint(sm) {
             flex-basis: 75%;
+        }
+
+        @include breakpoint(md) {
+            flex-basis: 80%;
         }
     }
 }

--- a/scss/v2/components/_promo.scss
+++ b/scss/v2/components/_promo.scss
@@ -56,9 +56,10 @@
 
     &__body {
         display: flex;
-        justify-content: space-evenly;
+        justify-content: flex-start;
         height: 100%;
         align-items: center;
+        padding-left: $baseline;
 
         &--column {
             display: flex;

--- a/scss/v2/components/_promo.scss
+++ b/scss/v2/components/_promo.scss
@@ -14,17 +14,26 @@
     }
 
     &__heading {
-        font-size: 30px;
-        font-weight: bold;
-        font-stretch: normal;
-        font-style: normal;
-        line-height: 1.33;
-        letter-spacing: -0.02px;
-    
         @include breakpoint(sm) {
             font-size: 18px;
             line-height: 1.78;
         }
+
+        @include breakpoint(md) {
+            font-size: 24px;
+            line-height: 1.78;
+        }
+
+        @include breakpoint(lg) {
+            font-size: 30px;
+            line-height: 1.33;
+            letter-spacing: -0.02px;
+        }
+
+        font-weight: bold;
+        font-stretch: normal;
+        font-style: normal;
+        line-height: 1.33;
     }
 
     &__description {
@@ -82,17 +91,17 @@
         }
     }
 
-    &__unicode {
-        font-size: 75px;
-    }
-
-    &__content {
+    &__copy {
         @include breakpoint(sm) {
             flex-basis: 75%;
         }
 
         @include breakpoint(md) {
             flex-basis: 70%;
+        }
+        
+        @include breakpoint(lg) {
+            flex-basis: auto;
         }
     }
 }

--- a/scss/v2/components/_promo.scss
+++ b/scss/v2/components/_promo.scss
@@ -73,35 +73,21 @@
         @include breakpoint(lg) {
             font-size: 30px;
             line-height: 1.33;
-            letter-spacing: -0.02px;
         }
 
         font-weight: bold;
-        font-stretch: normal;
-        font-style: normal;
         line-height: 1.33;
     }
 
     &__description {
         width: 100%;
-        word-wrap: break-word;
-        overflow-wrap: break-word;
-        font-size: 18px;
-        font-weight: normal;
-        font-stretch: normal;
-        font-style: normal;
-        line-height: 1.22;
-        letter-spacing: -0.13px;
-        color: #ffffff;
+        font-size: 16px;
+        line-height: normal;
+        color: $white;
 
-        @include breakpoint(sm) {
-            font-size: 16px;
-            line-height: normal;
-        }
-
-        @include breakpoint(md) {
-            font-size: 16px;
-            line-height: normal;
+        @include breakpoint(lg) {
+            font-size: 18px;
+            line-height: 1.22;
         }
     }
 }

--- a/scss/v2/components/_promo.scss
+++ b/scss/v2/components/_promo.scss
@@ -25,11 +25,6 @@
             font-size: 18px;
             line-height: 1.78;
         }
-
-        @include breakpoint(md) {
-            font-size: 18px;
-            line-height: 1.78;
-        }
     }
 
     &__description {
@@ -97,7 +92,7 @@
         }
 
         @include breakpoint(md) {
-            flex-basis: 80%;
+            flex-basis: 70%;
         }
     }
 }

--- a/scss/v2/components/_promo.scss
+++ b/scss/v2/components/_promo.scss
@@ -1,0 +1,80 @@
+.promo {
+    &__container {
+        display: block;
+
+        &:focus {
+            outline: 2px solid $pineapple-yellow;
+            outline-offset: 2px;
+        }
+
+        &:hover {
+            text-decoration: none;
+        }
+    }
+
+    &__heading {
+        font-size: 30px;
+        font-weight: bold;
+        font-stretch: normal;
+        font-style: normal;
+        line-height: 1.33;
+        letter-spacing: -0.02px;
+    
+        @include breakpoint(sm) {
+            font-size: 18px;
+            line-height: 1.78;
+        }
+    }
+
+    &__description {
+        font-size: 18px;
+        font-weight: normal;
+        font-stretch: normal;
+        font-style: normal;
+        line-height: 1.22;
+        letter-spacing: -0.13px;
+        color: #ffffff;
+
+        @include breakpoint(sm) {
+            font-size: 16px;
+            line-height: normal;
+        }
+    }
+
+    &__background {
+        &--blue-gradient {
+            background-image: linear-gradient(to bottom, $night-blue, $ocean-blue);
+            color: $white;
+        }
+
+        &--plum-gradient {
+            background-image: linear-gradient(to bottom, $plum-purple, $flamingo-pink);
+            color: $white;
+        }
+    }
+
+    &__body {
+        display: flex;
+        justify-content: space-evenly;
+        height: 100%;
+        align-items: center;
+
+        &--column {
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: flex-start;
+        }
+    }
+
+    &__unicode {
+        font-size: 75px;
+        font-family: initial;
+    }
+
+    &__content {
+        @include breakpoint(sm) {
+            flex-basis: 75%;
+        }
+    }
+}

--- a/scss/v2/components/_promo.scss
+++ b/scss/v2/components/_promo.scss
@@ -3,7 +3,7 @@
         display: block;
 
         &:focus {
-            outline: 2px solid $pineapple-yellow;
+            outline: 2px solid $sun-yellow;
             outline-offset: 2px;
             text-decoration: none;
         }
@@ -56,10 +56,9 @@
 
     &__body {
         display: flex;
-        justify-content: flex-start;
+        justify-content: space-evenly;
         height: 100%;
         align-items: center;
-        padding-left: $baseline;
 
         &--column {
             display: flex;
@@ -71,7 +70,6 @@
 
     &__unicode {
         font-size: 75px;
-        font-family: initial;
     }
 
     &__content {


### PR DESCRIPTION
### What

This PR adds the styles for the new promotional tiles - both the survey and census banners, housed in a `v2` directory.

![image](https://user-images.githubusercontent.com/23668262/80725113-8f5e4b00-8afa-11ea-9995-6f0b739ad147.png)

### How to review

- Check that the styles align with requirements
- You can view the banners themselves locally by pulling `feature/census-survey-banners` in `dp-frontend-renderer`, ensuring that `NEW_HOMEPAGE_ENABLED=true` in `dp-frontend-router` and running `dp-homepage-controller`.

### Who can review

Anyone but me
