### PR TITLE
Fix/homepage alignments

### DIFF
--- a/scss/v2/components/_promo.scss
+++ b/scss/v2/components/_promo.scss
@@ -2,6 +2,11 @@
     &__container {
         display: block;
 
+        @include breakpoint(sm) {
+            margin-left: -16px;
+            margin-right: -16px;
+        }
+
         &:focus {
             outline: 2px solid $sun-yellow;
             outline-offset: 2px;

--- a/scss/v2/components/tile.scss
+++ b/scss/v2/components/tile.scss
@@ -20,6 +20,7 @@
   }
 
   &__highlighted-content {
+    height: 340px;
     @include breakpoint(md) {
       height: 446px;
     }


### PR DESCRIPTION
### What

Couple of tweaks to the homepage styles in light of having more sections available to view the overall layout. This PR includes two fixes:

1. Inclusion of negative margins for the promotional banners so that in mobile viewports they fit the full width of the screen as per design spec
2. Specifying a fixed height for the highlighted content tiles for mobile viewports to ensure they are equally sized and spaced

### How to review

Ensure changes make sense

### Who can review

Anyone but me
