### PR TITLE
fix width of promo descriptions in IE11

### DIFF
--- a/scss/v2/components/_promo.scss
+++ b/scss/v2/components/_promo.scss
@@ -85,6 +85,7 @@
     &__description {
         font-size: 16px;
         color: $white;
+        width: 100%;
 
         @include breakpoint(lg) {
             font-size: 18px;


### PR DESCRIPTION
### What

One liner to make `width` explicit for `promo__description` for older browser compatibility (IE11, primarily). Without the width, text can stretch beyond the container at certain viewport sizes

### How to review

- Sense check the change

### Who can review

Anyone but me
