### PR TITLE
set latest releases to a fixed height

### DIFF
--- a/scss/v2/components/tile.scss
+++ b/scss/v2/components/tile.scss
@@ -19,6 +19,12 @@
         line-height: 1.5;
     }
 
+    &--latest-releases {
+        @include breakpoint(md) {
+            height: 521px;
+        }
+    }
+
     &__highlighted-content {
         height: 340px;
 


### PR DESCRIPTION
### What

- Added a modifier to the tile component so that latest releases has a fixed height in md/lg viewport sizes. This ensures it aligns with the bottom of the Census promo banner

### How to review

- Check in browser that the latest releases aligns with the bottom of the promo banners

### Who can review

Anyone but me
