### PR TITLE
Fix/cookies banner jitter

### DIFF
--- a/js/app/cookies-banner.js
+++ b/js/app/cookies-banner.js
@@ -12,9 +12,9 @@ var cookiesPath = "/";
 document.addEventListener("DOMContentLoaded", determineWhetherToRenderBanner());
 
 function determineWhetherToRenderBanner() {
-    if (cookiesSet || userIsOnCookiesPreferencesPage()) {
-        cookiesBanner.addClass("hidden");
-    } else {
+    const cookiesAreNotSet = !cookiesSet || userIsOnCookiesPreferencesPage()
+    if (cookiesAreNotSet) {
+        cookiesBanner.removeClass("cookies-banner--hidden")
         initCookiesBanner();
     }
 }

--- a/js/app/cookies-banner.js
+++ b/js/app/cookies-banner.js
@@ -12,7 +12,7 @@ var cookiesPath = "/";
 document.addEventListener("DOMContentLoaded", determineWhetherToRenderBanner());
 
 function determineWhetherToRenderBanner() {
-    const cookiesAreNotSet = !cookiesSet || userIsOnCookiesPreferencesPage()
+    var cookiesAreNotSet = !cookiesSet || userIsOnCookiesPreferencesPage()
     if (cookiesAreNotSet) {
         cookiesBanner.removeClass("cookies-banner--hidden")
         initCookiesBanner();
@@ -59,9 +59,9 @@ function hasCookiesPreferencesSet() {
 }
 
 function userIsOnCookiesPreferencesPage() {
-    var href = window.location.href.split("/")
+    var href = window.location.href.split("/");
 
     // check that last element in href array is 'cookies' - in case we add further pages within the cookies path
-    var isCookiesPreferencesPage = href[href.length - 1] === "cookies"
-    return isCookiesPreferencesPage
+    var isCookiesPreferencesPage = href[href.length - 1] === "cookies";
+    return isCookiesPreferencesPage;
 }

--- a/scss/components/_cookies-banner.scss
+++ b/scss/components/_cookies-banner.scss
@@ -7,6 +7,10 @@
         padding: 10px 0;
     }
 
+    .js &--hidden {
+        display: none !important;
+    }
+
     &__wrapper {
         margin-left: auto;
         margin-right: auto;


### PR DESCRIPTION
### What

This PR adds a new `--hidden` modifier to the `cookies-banner` component that is triggered when the `js` class is present in a parent element.

This addition subsequently fixes the jitter issue that was present on the website, where if cookies preferences were set and JS is enabled, the non-js version of the cookies banner is flashed on screen before being hidden away.

**Bit more context on why approach here slightly differs to one mentioned in ticket**

The initial plan was to use the `js-hidden` class. The underpinning logic for this would be to have a `js` class in the `body` element, applied by JavaScript, and then each child element that has `js-hidden` would be hidden. However, in Sixteens, `.js-hidden` seems to set `display: none;` even when the `js` class is not set in the body. 

My initial plan was to fix this, as the class name suggests the element should be hidden when JS is enabled. However, `js-hidden` was being used in a number of different pages and components, seemingly for different behaviours. In some instances, it seemed like it was solely being used instead of `hidden` to hide the element for JS and non-JS enabled versions of the site. Other parts of the codebase, `js-hidden` was used to hide the element for both JS/Non-JS versions of the site, but also to include additional logic for different components. Owing to this inconsistency, it felt as though more involved changes to other parts of the codebase would be required for this approach than simply changing all `js-hidden` instances to `hidden` if we wanted to retain the same behaviours for the JS/non-JS enabled versions of the site. This is potentially out of scope for this bug fix ticket anyway, but I also felt uncomfortable changing things across numerous components, especially without any tests in place, as this could possibly lead to regressions or other aspects of functionality not remaining the same.

Instead I've applied a different pattern that I saw was being used in the GOV UK frontend codebase, where the component partial itself now has a `.js &--hidden` rule. In this instance, that means the cookies banner now has a selector which translates to `js .cookies-banner--hidden`. 

This subsequently hides the cookies banner when JavaScript is enabled on initial load. JavaScript is then used to display the banner if the user still hasn't set their cookies preferences. The non-JS version retains its behaviour as intended.

### How to review

- Check code changes make sense
- Run this branch alongside the `fix/cookies-banner-jitter` in both Babbage and the frontend renderer.
- Remove `cookies_preferences` cookie and refresh the page. The Cookies banner should now be present at the top of the page again.
- Accept all cookies, then navigate to another page on the site. Go onto the homepage by entering the URL in the address; this is a known case of where the cookies banner would have jittered in the past.

### Who can review

Anyone but me
