### PR TITLE
Feature/updated homepage layout

### DIFF
--- a/scss/utilities/_height.scss
+++ b/scss/utilities/_height.scss
@@ -1,7 +1,7 @@
 //height
 @mixin height-util {
     .height {
-        @for $i from 0 through 54 {
+        @for $i from 0 through 60 {
             @include breakpoint(sm) {
                 &-sm--#{$i} {
                     height: ($baseline * $i);
@@ -16,7 +16,7 @@
                 }
             }
         }
-        @for $i from 0 through 54 {
+        @for $i from 0 through 60 {
             @include breakpoint(md) {
                 &-md--#{$i} {
                     height: ($baseline * $i);
@@ -31,7 +31,7 @@
                 }
             }
         }
-        @for $i from 0 through 54 {
+        @for $i from 0 through 60 {
             @include breakpoint(lg) {
                 &-lg--#{$i} {
                     height: ($baseline * $i);
@@ -46,7 +46,7 @@
                 }
             }
         }
-        @for $i from 0 through 54 {
+        @for $i from 0 through 60 {
             &--#{$i} {
                 height: ($baseline * $i);
 
@@ -65,28 +65,28 @@
 
 @mixin min-height-util {
     .min-height {
-        @for $i from 0 through 54 {
+        @for $i from 0 through 60 {
             @include breakpoint(sm) {
                 &-sm--#{$i} {
                     min-height: ($baseline * $i);
                 }
             }
         }
-        @for $i from 0 through 54 {
+        @for $i from 0 through 60 {
             @include breakpoint(md) {
                 &-md--#{$i} {
                     min-height: ($baseline * $i);
                 }
             }
         }
-        @for $i from 0 through 54 {
+        @for $i from 0 through 60 {
             @include breakpoint(lg) {
                 &-lg--#{$i} {
                     min-height: ($baseline * $i);
                 }
             }
         }
-        @for $i from 0 through 54 { //
+        @for $i from 0 through 60 { //
             &--#{$i} {
                 min-height: ($baseline * $i);
             }
@@ -97,14 +97,14 @@
 
 @mixin max-height-util {
     .max-height {
-        @for $i from 0 through 540 {
+        @for $i from 0 through 600 {
             @include breakpoint(md) {
                 &-md--#{$i} {
                     max-height: ($baseline * $i);
                 }
             }
         }
-        @for $i from 0 through 54 { 
+        @for $i from 0 through 60 { 
             &--#{$i} {
                 max-height: ($baseline * $i);
             }

--- a/scss/v2/components/_promo.scss
+++ b/scss/v2/components/_promo.scss
@@ -60,7 +60,7 @@
         }
 
         @include breakpoint(md) {
-            flex-basis: 80%;
+            flex-basis: 90%;
         }
         
         @include breakpoint(lg) {

--- a/scss/v2/components/tile.scss
+++ b/scss/v2/components/tile.scss
@@ -26,6 +26,17 @@
         }
     }
 
+    &__content-container {
+        &--space-between {
+            display: flex;
+            flex-direction: column;
+            flex: 1 1 auto;
+            justify-content: space-between;
+            height: 77%;
+            
+        }
+    }
+
     &__highlighted-content {
         height: 340px;
 

--- a/scss/v2/components/tile.scss
+++ b/scss/v2/components/tile.scss
@@ -19,9 +19,10 @@
         line-height: 1.5;
     }
 
-    &--latest-releases {
+    &--employment-figures-stacked {
+        // Fixed height on md to ensure employment figures tile is flush with population tile
         @include breakpoint(md) {
-            height: 521px;
+            height: 840px;
         }
     }
 

--- a/scss/v2/components/tile.scss
+++ b/scss/v2/components/tile.scss
@@ -33,7 +33,6 @@
             flex: 1 1 auto;
             justify-content: space-between;
             height: 77%;
-            
         }
     }
 
@@ -111,7 +110,6 @@
             }
         }
     }
-
     &__link {
         font-size: 18px;
         line-height: 1.78;
@@ -230,7 +228,7 @@
         }
     }
 
-    &__highlighted-content-summary {
+    &__text-description {
         font-size: inherit;
         line-height: 1.78;
         color: $black;


### PR DESCRIPTION
### What

This PR includes changes in order to update the homepage layout for lg and md viewports:

- Increased the number of height utility classes to 60 to accommodate new sizing for the tiles on the homepage
- Increased flex-basis value for `md` promo tiles to make use of the additional space, now that the tiles are adjacent
- Added styles to tweak the tiles. The latest release tile uses `flex` in order to space apart the text and the link.
- Renamed `__highlighted-content-summary` to `__text-description` as this is now used in the Latest Releases tile as well as the highlighted content block
- Added a fixed height to be used in `md` viewport for the stacked employment figures

### How to review

- Pull `feature/updated-homepage-layout` from the frontend renderer and run alongside these changes to view the new homepage
- Check that the code changes make sense

### Who can review

Anyone but me
