### PR TITLE
decrease employment tile size in md viewport

### DIFF
--- a/scss/v2/components/tile.scss
+++ b/scss/v2/components/tile.scss
@@ -22,7 +22,7 @@
     &--employment-figures-stacked {
         // Fixed height on md to ensure employment figures tile is flush with population tile
         @include breakpoint(md) {
-            height: 840px;
+            height: 776px;
         }
     }
 


### PR DESCRIPTION
### What

Decreased the height of the `--employment-figures-stacked` modifier. This is because this tile in `md` viewport is now using `col-md--15` instead of `col-md--12`. This means the content of the employment tile doesn't need as much space

### How to review

- Sense check the change
- Can be viewed locally by running `fix/employment-md-view` branch in `dp-frontend-renderer` alongside this one and going to a tablet viewport size (min-width: 768px)

### Who can review

Anyone but me
