### PR TITLE
Fix - Remove visually hidden override using display none

### DIFF
--- a/scss/elements/_dp-table-renderer.scss
+++ b/scss/elements/_dp-table-renderer.scss
@@ -68,10 +68,6 @@
     text-decoration: none;
 }
 
-.visuallyhidden {
-    display: none
-}
-
 .figure__footnotes li:target {
     animation: footer-pulse 5s;
     animation-iteration-count: 1;

--- a/scss/utilities/_utilities.scss
+++ b/scss/utilities/_utilities.scss
@@ -22,6 +22,7 @@
 	border: 0;
 	overflow: hidden;
 	clip: rect(0 0 0 0);
+	white-space: nowrap;
 
   	// Extends the .visuallyhidden class to allow the element to be focusable when navigated to via the keyboard: h5bp.com/p
   	&.focusable:active,


### PR DESCRIPTION
~~THIS BUILDS ON #200~~

### What
This removes the visuallyhidden class that was overriding the correct styles for a screen only element

Additionally this updates the class as per the html5boilerplate (where it originated) to improve screen reader text processing. Details are provided in the commit.

### How to review
1. See that the visuallyhidden class has been removed so no longer uses `display: none`
1. See that visually the page is unchanged.
1. Hear that content styled using `visuallyhidden` is read by a screen reader
### Who can review
Anyone
