### PR TITLE
added list utility class to remove pipe on specific list items

### DIFF
--- a/scss/elements/_lists.scss
+++ b/scss/elements/_lists.scss
@@ -66,7 +66,7 @@
 		}
 	}
 
-	&--no-pipe:after {
+	&--no-separator:after {
 		content: "" !important;
 	}
 	

--- a/scss/elements/_lists.scss
+++ b/scss/elements/_lists.scss
@@ -65,6 +65,10 @@
 			}
 		}
 	}
+
+	&--no-pipe:after {
+		content: "" !important;
+	}
 	
 	&--ellipses {
 		&-md{


### PR DESCRIPTION
### What

This change adds a new `list--no-pipe` utility class that allows us to remove `:after` content from an individual element

This change has been added to address the styling change that occurs after changing the HTML in the list of a CMD filter page. We originally had a `span` nested within a `ul` - this has now been changed to a `li` element - [PR here](https://github.com/ONSdigital/dp-frontend-renderer/pull/439) 

As we use a html tag as a selector in the relevant class, BEM's flat specificity rule is broken; to that end it felt like creating a separate utility class that could be individually applied to `li` tags would be a more flexible solution

**Without utility class**
![image](https://user-images.githubusercontent.com/23668262/88627336-13957f80-d0a4-11ea-9477-190938eaf6b9.png)

**With utility class**
![image](https://user-images.githubusercontent.com/23668262/88627305-037da000-d0a4-11ea-8f3a-51291c83688b.png)


### How to review

Check that the styling change makes sense

### Who can review

Anyone but me
