### PR TITLE
Fix - Accessible CMD filters clickable but visually disabled

### DIFF
--- a/js/app/filter-options.js
+++ b/js/app/filter-options.js
@@ -30,11 +30,7 @@ $(document).ready(function() {
             $("#error-container").append("<div id=\"options-error\" class=\"font-size--16 form-error filter-overview__error-message margin-bottom--1\">Add at least one filter to '" + errorDimensions + "' to generate data</div>")
             $("#error-container").append("<div class=\"font-size--16 margin-bottom--4\"> Alternatively, return to the <a href=\""+landingPageUrl+"\">landing page</a> to download the complete dataset.</div>")
         }
-    }) 
-
-    if ($("li#filter-option.filter-overview__add").length > 0) {
-        $("#preview-download").addClass("btn--primary-disabled");
-    }
+    })
 
     $("li#filter-option").hover(function() {
         var label = $(this).find("#filter-option-label");


### PR DESCRIPTION
### What
The button for applying filters in CMD was visually disabled but clickable. When clicked it would show any errors that you had. After discussions with UX this visual disabling has been removed. This was applied when there were any errors.

This visual disabling was done in HTML as well so you will also need to checkout dp-frontend-renderer [fix/accessible-cmd-filter-errors](https://github.com/ONSdigital/dp-frontend-renderer/tree/fix/accessible-cmd-filter-errors)

### How to review
1. View the CMD filter page
1. See that the apply filter button is visually disabled but clickable
1. See that the errors are not announced to the screen reader when clicked.
1. Switch to this PR and the sixteens branch.
1. See that the button is no longer visually
1. See that the errors are announced as expected

### Who can review
Anyone but me
