### PR TITLE
Fix - Disable polyfill when not needed

### DIFF
--- a/js/thirdparty/details.polyfill.js
+++ b/js/thirdparty/details.polyfill.js
@@ -13,6 +13,10 @@
   var KEY_ENTER = 13
   var KEY_SPACE = 32
 
+  if (NATIVE_DETAILS) {
+    return;
+  }
+
   // Add event construct for modern browsers or IE
   // which fires the callback with a pre-converted target reference
   function addEvent (node, type, callback) {


### PR DESCRIPTION
### What
The details polyfill adds lots of aria attributes and makes using a details very confusing. This is no longer required as all of the browsers we support (apart for IE11) have full support for details and works well. 

### How to review
1. Open a page with a `<details>` e.g. a CMD dataset filter with a description
1. See that the details expand and collapse but is confusing with a screen reader
1. Switch to this branch and `dp-frontend-renderer` `fix/accessibility-remove-details-roles`
1. See that details are more straight forward from a screen reader and still work 

### Who can review
Anyone but me
