### PR TITLE
update the show/hide functions for the menu and search

### DIFF
--- a/js/app/nav.js
+++ b/js/app/nav.js
@@ -24,18 +24,21 @@ function collapseSubnav(element) {
 
 function showMenu(toggleElement, menuElement) {
     toggleElement.addClass('menu-is-expanded');
+    toggleElement.find('a').attr('aria-expanded', true);
     menuElement.removeClass('nav-main--hidden');
     menuElement.attr('aria-expanded', true);
 }
 
 function hideMenu(toggleElement, menuElement) {
     toggleElement.removeClass('menu-is-expanded');
+    toggleElement.find('a').attr('aria-expanded', false);
     menuElement.addClass('nav-main--hidden');
     menuElement.attr('aria-expanded', false);
 }
 
 function showSearch(toggleElement, searchElement) {
     toggleElement.addClass('search-is-expanded');
+    toggleElement.find('a').attr('aria-expanded', true);
     toggleElement.find('.nav--controls__icon')
         .removeClass('icon-search-1')
         .addClass('icon-cancel');
@@ -46,6 +49,7 @@ function showSearch(toggleElement, searchElement) {
 
 function hideSearch(toggleElement, searchElement) {
     toggleElement.removeClass('search-is-expanded');
+    toggleElement.find('a').attr('aria-expanded', false);
     toggleElement.find('.nav--controls__icon')
         .removeClass('icon-cancel')
         .addClass('icon-search-1');


### PR DESCRIPTION
### What

Extended show/hide functions for the Menu and Search toggles to update aria-expanded attributes

### How to review

1 - Emulate/use a mobile device and screen reader
2 - Navigate to the homepage.
3 - Click on the 'Menu' toggle in the navigation.
4 - The screen reader should announce the details of the button you clicked on, included that the menu is expanded.
5 - Click the 'Menu' toggle again
6 - The screen reader should announce that the menu is now collapsed.
7 - Repeat for the 'Search' button

### Who can review
