### PR TITLE
Fix - Covid text contrast

### DIFF
--- a/scss/utilities/_colours.scss
+++ b/scss/utilities/_colours.scss
@@ -31,6 +31,7 @@ $blue:          	#3a7db4;
 $indigo:			#560072;
 $prim:				#E8DFF0;
 $pineapple-yellow:	#fbc900;
+$night-blue: #003c57;
 
 //Colour types
 $primary:       $salem;
@@ -64,7 +65,7 @@ $colours: (
 		("astral", 				$astral, 				$haze)
 		("indigo",				$indigo,				$iron-light)
 		("prim",				$prim,					$thunder)
-		("pineapple-yellow",	$pineapple-yellow, 		$thunder)
+		("pineapple-yellow",	$pineapple-yellow, 		$thunder, $night-blue)
 );
 
 


### PR DESCRIPTION
### What
Change the link colour for the covid banner to increase contrast

### How to review
1. Load the new home page
1. See that the link in the banner does not stand out against the yellow background
1. Switch to this branch and `dp-frontend-renderer` branch `fix/covid-banner-contrast`
1. See that it is now improved and using colour `#003c57`

### Who can review
Anyone but me
