### PR TITLE
update css so the datepicker button is still visible when aria-hidden…

### DIFF
--- a/scss/utilities/_utilities.scss
+++ b/scss/utilities/_utilities.scss
@@ -400,6 +400,10 @@
      }
  }
 
+.datepicker__icon[aria-hidden*=true] {
+  visibility: initial;
+}
+
 #viewport {
 
     &-sm {


### PR DESCRIPTION
… is set true

### What

Updated the utilities css to show the date picker button when it has aria-hidden set to true.

### How to review

(Needs to be run with the branch of the same name in babbage)
- navigate to the /releasecalendar page.
- inspect the date picker button it should have the aria-hidden attribute set to true.
- the date picker button should still be visible

### Who can review

Anyone but me.
