### PR TITLE
add polyfill for the details expansion and collapse

### DIFF
--- a/js/thirdparty/details.polyfill.js
+++ b/js/thirdparty/details.polyfill.js
@@ -9,6 +9,18 @@
 ;(function () {
   'use strict'
 
+  //polyfill for details expansion/collapse in Voiceover on iOS
+  $(function() {
+    var embedCodeBtns = $('details').find('summary');
+
+    if (embedCodeBtns.length) {
+      embedCodeBtns.attr('aria-expanded', false)
+      embedCodeBtns.click(function () {
+        $(this).attr('aria-expanded', $(this).attr('aria-expanded') === 'false');
+      });
+    }
+  });
+
   var NATIVE_DETAILS = typeof document.createElement('details').open === 'boolean'
   var KEY_ENTER = 13
   var KEY_SPACE = 32


### PR DESCRIPTION
### What

Added aria-expanded attribute to the 'Embed Code' toggle to assist screen reader users.

### How to review

- Use a screenreader
- Navigate to a data page that contains an 'Embed Code' option.
- move focus to the 'Embed Code' toggle, the screen reader should announce the details of the toggle, including that it is collapsed.
- Click the 'Embed Code' button
- The details should become visible and screen reader should announce that it is expanded.

### Who can review

Anyone but me
