### PR TITLE
Fix - Download as link

### DIFF
--- a/js/app/table-of-contents.js
+++ b/js/app/table-of-contents.js
@@ -28,7 +28,7 @@ $(function() {
 
         //add in print options
         if ($('.js-print-pdf').length > 0) {
-            var printStickyWrap = $('<div class="col col--md-17 col--lg-19 hide--sm"><p class="text-right padding-top-md--0 padding-bottom-md--0 margin-bottom-md--1 print--hide"><a href="" id="" class="link-complex nojs-hidden js-enhance--show js-print-page">Print this page&nbsp;</a><span class="icon icon-print--light-small"></span></p><p class="text-right padding-top-md--0 padding-bottom-md--1 margin-top-md--0 margin-bottom-md--0 print--hide js-enhance--show"><a href="' + pdfDownloadLink + ' " class="link-complex">Download as PDF&nbsp;</a><span class="icon icon-download--light-small"></span></p></div>');
+            var printStickyWrap = $('<div class="col col--md-17 col--lg-19 hide--sm"><p class="text-right padding-top-md--0 padding-bottom-md--0 margin-bottom-md--1 print--hide"><a href="" id="" class="link-complex nojs-hidden js-enhance--show js-print-page">Print this page&nbsp;</a><span class="icon icon-print--light-small"></span></p><p class="text-right padding-top-md--0 padding-bottom-md--1 margin-top-md--0 margin-bottom-md--0 print--hide js-enhance--show"><a href="' + pdfDownloadLink + ' " class="link-complex" aria-label="Download current page as PDF">Download as PDF&nbsp;</a><span class="icon icon-download--light-small"></span></p></div>');
             $(printStickyWrap).insertAfter($('.table-of-contents--sticky__wrap .col'));
         }
 


### PR DESCRIPTION
### What
Update download pdf in header bar when on content pages to include a more descriptive label. The header bar shows after you have scrolled down the page a bit.

### How to review
1. Hear that the download page link in header is confusing (or see in link rotor)
1. Switch to this branch
1. Hear that it makes more sense

### Who can review
Anyone but me
