### PR TITLE
Reflow - Hompage in focus and timeseries legend

### DIFF
--- a/scss/components/_chart-area.scss
+++ b/scss/components/_chart-area.scss
@@ -107,6 +107,12 @@
         * {
             font-family: $base-font-family;
         }
+
+        @include breakpoint(sm) {
+            .highcharts-legend {
+                display: none;
+            }
+        }
     }
 
     &__controls__download {

--- a/scss/utilities/_breakpoints.scss
+++ b/scss/utilities/_breakpoints.scss
@@ -8,7 +8,11 @@
 	}
 
 	@else {
-		@if $class == sm {
+		@if $class == xs {
+			@media (max-width: 330px) { @content; }
+		}
+
+		@else if $class == sm {
 			@media (max-width: 767px) { @content; }
 		}
 

--- a/scss/v2/components/tile.scss
+++ b/scss/v2/components/tile.scss
@@ -39,6 +39,11 @@
     &__highlighted-content {
         height: 340px;
 
+        @include breakpoint(xs) {
+            height: auto;
+            min-height: 340px;
+        }
+
         @include breakpoint(md) {
             height: 446px;
         }


### PR DESCRIPTION
### What
Fixes for very small screens (aka reflow - 320px wide or 1280px wide + 400% zoom)
1. Home page inflow item text overflowing 
1. Timeseries page linechart legend overflowing on small and extra small screens

### How to review
1. Using a browser at either 320px wide or 1280px wide and with 400% zoom
1. Visit a page above
1. See the layout issue described
1. Switch to this PR
1. See that it is fixed

### Who can review
Anyone but me
