### PR TITLE
Fix - Main navigation

### DIFF
--- a/scss/components/_header.scss
+++ b/scss/components/_header.scss
@@ -57,7 +57,7 @@
                 background-color: $thunder;
                 color: $white;
                 text-decoration: none;
-                left: auto; //resets child-items to appear on-screen
+                display: block;
                 top: 86px; //2px less to cover borders on parent
             }
 
@@ -133,7 +133,7 @@
             @include breakpoint(md) {
                 background-color: $thunder;
                 text-decoration: none;
-                left: auto; //resets child-items to appear on-screen
+                display: block;
                 top: 86px; //2px less to cover same colour border on parent <li>
             }
 
@@ -165,7 +165,7 @@
             position: absolute;
             padding: 0;
             z-index: 10;
-            left: -99999px; //used instead of display:none so it's accessible to screen readers
+            display: none;
             border: 1px solid $thunder;
         }
     }


### PR DESCRIPTION
### What
Hide the submenus from screenreaders until they are expanded.

Hidden only with `display: none` as it is not recommended to also use `aria-hidden` https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-hidden_attribute#Best_practices

### How to review
1. Visit any page
1. See that the link rotor contains all images and that screen reader navigation takes you to all submenu links even when the navigation menu is collapsed.
1. Switch to this branch
1. See that the links are no longer in the rotor and you cannot navigate until you expand the menu 

### Who can review
Anyone but me
