### PR TITLE
Bug - Add aria-label to download links added by JS

### DIFF
--- a/js/app/preview.js
+++ b/js/app/preview.js
@@ -85,7 +85,7 @@ function addFilesToPage(files) {
         csvFile = $('<li class="padding-left--1 margin-top--0 margin-bottom--1 white-background clearfix">' +
                     '<span class="inline-block width--24 padding-top--2">Filtered dataset (<span class="uppercase">csv</span> format)</span>' +
                     '<div class="width--12 inline-block float-right text-right">' +
-                    '<a id="csv-download" class="btn btn--primary margin-top--1 margin-bottom--1 margin-right--half width--11" href="' + csvURL + '"><strong>csv</strong> ('+ formatBytes(csvFileSize) +')</a></div></li>');
+                    '<a id="csv-download" class="btn btn--primary margin-top--1 margin-bottom--1 margin-right--half width--11" href="' + csvURL + '" aria-label="Download the filtered dataset as csv (' + formatBytes(csvFileSize) + ')"><strong>csv</strong> ('+ formatBytes(csvFileSize) +')</a></div></li>');
 
     // Get the xls data and create the link
     var excelURL = files.downloads.xls.href,
@@ -94,14 +94,14 @@ function addFilesToPage(files) {
 
     var excelFile = "";
     if (excelFileSize > 0) {
-      excelFile = $('<a id="excel-download" class="btn btn--primary btn--thick margin-bottom--4 btn--focus font-size--19" href=" ' + excelURL + '"><strong>Excel file</strong> <span class="font-size--14">('+ formatBytes(excelFileSize) +')</span></a>');
+      excelFile = $('<a id="excel-download" class="btn btn--primary btn--thick margin-bottom--4 btn--focus font-size--19" href=" ' + excelURL + '" aria-label="Download the filtered dataset as an excel file (' + formatBytes(excelFileSize) + ')"><strong>Excel file</strong> <span class="font-size--14">('+ formatBytes(excelFileSize) +')</span></a>');
     }
 
     if (excelSkipped) {
       excelFile = $('<div class="status status--amber col--lg-two-thirds col--md-two-thirds" id="excel-skipped">' +
                     '<p class="flush status__content">There are too many cells to create an Excel file. ' +
                     '<a href="/filters/' + files.links.filter_blueprint.id + '/dimensions">Adjust the filter options</a>' +
-                    ' or <a href="' + csvURL + '">download the CSV (' + formatBytes(csvFileSize) + ')</a>.' +
+                    ' or <a href="' + csvURL + '" aria-label="Download the filtered dataset as csv (' + formatBytes(csvFileSize) + ')">download the CSV (' + formatBytes(csvFileSize) + ')</a>.' +
                     '</p>' +
                     '</div>');
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -335,7 +335,8 @@
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
             "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "basic-auth": {
             "version": "1.1.0",
@@ -529,7 +530,8 @@
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
                     "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "got": {
                     "version": "8.3.2",
@@ -607,6 +609,7 @@
                     "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
                     "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "p-finally": "^1.0.0"
                     }
@@ -648,6 +651,7 @@
             "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
             "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "readable-stream": "^2.3.5",
                 "safe-buffer": "^5.1.1"
@@ -670,7 +674,8 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
             "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "brace-expansion": {
             "version": "1.1.11",
@@ -695,6 +700,7 @@
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
             "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "base64-js": "^1.0.2",
                 "ieee754": "^1.1.4"
@@ -705,6 +711,7 @@
             "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
             "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "buffer-alloc-unsafe": "^1.1.0",
                 "buffer-fill": "^1.0.0"
@@ -714,19 +721,22 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
             "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "buffer-crc32": {
             "version": "0.2.13",
             "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
             "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "buffer-fill": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
             "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "cacheable-request": {
             "version": "2.1.4",
@@ -841,6 +851,7 @@
             "resolved": "https://registry.npmjs.org/caw/-/caw-2.0.1.tgz",
             "integrity": "sha512-Cg8/ZSBEa8ZVY9HspcGUYaK63d/bN7rqS3CYCzEGUxuYv6UlmcjzDUz2fCFFHyTvUW5Pk0I+3hkA3iXlIj6guA==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "get-proxy": "^2.0.0",
                 "isurl": "^1.0.0-alpha5",
@@ -1036,6 +1047,7 @@
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
             "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "graceful-readlink": ">= 1.0.0"
             }
@@ -1050,6 +1062,7 @@
             "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
             "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "ini": "^1.3.4",
                 "proto-list": "~1.2.1"
@@ -1072,6 +1085,7 @@
             "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
             "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "safe-buffer": "5.1.2"
             }
@@ -1232,6 +1246,7 @@
             "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.1.tgz",
             "integrity": "sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "decompress-tar": "^4.0.0",
                 "decompress-tarbz2": "^4.0.0",
@@ -1248,6 +1263,7 @@
                     "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
                     "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "pify": "^3.0.0"
                     },
@@ -1256,7 +1272,8 @@
                             "version": "3.0.0",
                             "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
                             "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         }
                     }
                 }
@@ -1267,6 +1284,7 @@
             "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
             "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "mimic-response": "^1.0.0"
             }
@@ -1276,6 +1294,7 @@
             "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
             "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "file-type": "^5.2.0",
                 "is-stream": "^1.1.0",
@@ -1286,7 +1305,8 @@
                     "version": "5.2.0",
                     "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
                     "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
@@ -1295,6 +1315,7 @@
             "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
             "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "decompress-tar": "^4.1.0",
                 "file-type": "^6.1.0",
@@ -1307,7 +1328,8 @@
                     "version": "6.2.0",
                     "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
                     "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
@@ -1316,6 +1338,7 @@
             "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
             "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "decompress-tar": "^4.1.1",
                 "file-type": "^5.2.0",
@@ -1326,7 +1349,8 @@
                     "version": "5.2.0",
                     "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
                     "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
@@ -1335,6 +1359,7 @@
             "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
             "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "file-type": "^3.8.0",
                 "get-stream": "^2.2.0",
@@ -1346,13 +1371,15 @@
                     "version": "3.9.0",
                     "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
                     "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "get-stream": {
                     "version": "2.3.1",
                     "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
                     "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "object-assign": "^4.0.1",
                         "pinkie-promise": "^2.0.0"
@@ -1497,21 +1524,23 @@
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
                     "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
         "duplexer": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-            "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+            "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
             "dev": true
         },
         "duplexer3": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
             "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "ecc-jsbn": {
             "version": "0.1.2",
@@ -1544,6 +1573,7 @@
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
             "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "once": "^1.4.0"
             }
@@ -1674,6 +1704,7 @@
             "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
             "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "cross-spawn": "^6.0.0",
                 "get-stream": "^4.0.0",
@@ -1689,6 +1720,7 @@
                     "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
                     "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "nice-try": "^1.0.4",
                         "path-key": "^2.0.1",
@@ -1714,6 +1746,7 @@
             "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
             "integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "mime-db": "^1.28.0"
             }
@@ -1723,6 +1756,7 @@
             "resolved": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
             "integrity": "sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "ext-list": "^2.0.0",
                 "sort-keys-length": "^1.0.0"
@@ -1776,6 +1810,7 @@
             "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
             "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "pend": "~1.2.0"
             }
@@ -1801,13 +1836,15 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
             "integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "filenamify": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-2.1.0.tgz",
             "integrity": "sha512-ICw7NTT6RsDp2rnYKVd8Fu4cr6ITzGy3+u4vUujPkabyaz+03F24NWEX7fs5fp+kBonlaqPH8fAO2NM+SXt/JA==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "filename-reserved-regex": "^2.0.0",
                 "strip-outer": "^1.0.0",
@@ -1878,7 +1915,8 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
             "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "fs.realpath": {
             "version": "1.0.0",
@@ -1942,6 +1980,7 @@
             "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-2.1.0.tgz",
             "integrity": "sha512-zmZIaQTWnNQb4R4fJUEp/FC51eZsc6EkErspy3xtIYStaq8EB/hDIWipxsal+E8rz0qD7f2sL/NA9Xee4RInJw==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "npm-conf": "^1.1.0"
             }
@@ -1956,6 +1995,7 @@
             "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
             "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "pump": "^3.0.0"
             }
@@ -2042,7 +2082,8 @@
                     "version": "3.1.1",
                     "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
                     "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "shebang-command": {
                     "version": "2.0.0",
@@ -2174,7 +2215,8 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
             "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "har-schema": {
             "version": "2.0.0",
@@ -2222,7 +2264,8 @@
             "version": "1.4.2",
             "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
             "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "has-symbols": {
             "version": "1.0.1",
@@ -2235,6 +2278,7 @@
             "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
             "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "has-symbol-support-x": "^1.4.1"
             }
@@ -2319,7 +2363,8 @@
             "version": "1.1.13",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
             "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "ignore": {
             "version": "5.1.8",
@@ -2641,7 +2686,8 @@
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
             "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "into-stream": {
             "version": "3.1.0",
@@ -2750,7 +2796,8 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
             "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "is-number": {
             "version": "7.0.0",
@@ -2762,7 +2809,8 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
             "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "is-plain-obj": {
             "version": "1.1.0",
@@ -2790,13 +2838,15 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
             "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "is-stream": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
             "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "is-svg": {
             "version": "4.2.1",
@@ -2847,6 +2897,7 @@
             "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
             "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "has-to-string-tag-x": "^1.2.0",
                 "is-object": "^1.0.1"
@@ -3106,7 +3157,8 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
             "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "lpad-align": {
             "version": "1.1.2",
@@ -3228,7 +3280,8 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
             "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "min-indent": {
             "version": "1.0.1",
@@ -3297,7 +3350,8 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
             "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "node-gyp": {
             "version": "3.8.0",
@@ -3410,6 +3464,7 @@
             "resolved": "https://registry.npmjs.org/npm-conf/-/npm-conf-1.1.3.tgz",
             "integrity": "sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "config-chain": "^1.1.11",
                 "pify": "^3.0.0"
@@ -3419,7 +3474,8 @@
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
                     "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
@@ -3428,6 +3484,7 @@
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
             "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "path-key": "^2.0.0"
             }
@@ -3742,7 +3799,8 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
             "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "p-is-promise": {
             "version": "1.1.0",
@@ -3795,6 +3853,7 @@
             "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
             "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "p-finally": "^1.0.0"
             }
@@ -3829,7 +3888,8 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
             "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "path-parse": {
             "version": "1.0.6",
@@ -3850,7 +3910,8 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
             "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "performance-now": {
             "version": "2.1.0",
@@ -3917,7 +3978,8 @@
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
             "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "pseudomap": {
             "version": "1.0.2",
@@ -3934,6 +3996,7 @@
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
             "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
@@ -4354,6 +4417,7 @@
             "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
             "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "commander": "~2.8.1"
             }
@@ -4396,6 +4460,7 @@
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "shebang-regex": "^1.0.0"
             }
@@ -4404,7 +4469,8 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
             "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "shell-quote": {
             "version": "1.4.3",
@@ -4440,6 +4506,7 @@
             "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
             "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "is-plain-obj": "^1.0.0"
             }
@@ -4449,6 +4516,7 @@
             "resolved": "https://registry.npmjs.org/sort-keys-length/-/sort-keys-length-1.0.1.tgz",
             "integrity": "sha1-nLb09OnkgVWmqgZx7dM2/xR5oYg=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "sort-keys": "^1.0.0"
             }
@@ -4614,6 +4682,7 @@
             "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
             "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "is-natural-number": "^4.0.1"
             }
@@ -4622,7 +4691,8 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
             "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "strip-final-newline": {
             "version": "2.0.0",
@@ -4644,6 +4714,7 @@
             "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
             "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "escape-string-regexp": "^1.0.2"
             }
@@ -4724,6 +4795,7 @@
             "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
             "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "bl": "^1.0.0",
                 "buffer-alloc": "^1.2.0",
@@ -4738,13 +4810,15 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
             "integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "tempfile": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-2.0.0.tgz",
             "integrity": "sha1-awRGhWqbERTRhW/8vlCczLCXcmU=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "temp-dir": "^1.0.0",
                 "uuid": "^3.0.1"
@@ -4760,13 +4834,15 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
             "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "to-buffer": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
             "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "to-regex-range": {
             "version": "5.0.1",
@@ -4802,6 +4878,7 @@
             "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
             "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "escape-string-regexp": "^1.0.2"
             }
@@ -4843,6 +4920,7 @@
             "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
             "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "buffer": "^5.2.1",
                 "through": "^2.3.8"
@@ -4892,7 +4970,8 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
             "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "util-deprecate": {
             "version": "1.0.2",
@@ -5023,7 +5102,8 @@
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
             "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "y18n": {
             "version": "4.0.0",
@@ -5111,6 +5191,7 @@
             "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
             "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "buffer-crc32": "~0.2.3",
                 "fd-slicer": "~1.1.0"


### PR DESCRIPTION
### What
Add aria-label to CMD filter download links when the generation is completed as these are added by JS

### How to review
1. Filter a CMD dataset and get to the download page (do not refresh)
1. See that the links do not include download labels
1. Switch to this branch and do it again
1. See that they do

### Who can review
Anyone but me
