### PR TITLE
add aria hidden to the excel file tag if its required

### DIFF
--- a/js/app/preview.js
+++ b/js/app/preview.js
@@ -63,6 +63,7 @@ function getDownloadFiles() {
         if (count < 60) {
             count++;
             loader.removeClass('js-hidden');
+            $('#excel-file').attr('aria-hidden', true);
             if (count === 1) {
                 preparingAlert.prependTo(loader);
             }


### PR DESCRIPTION
### What

Set aria-hidden on the excel-file tag if the file isn't ready on page load.

### How to review

- Apply filters to a dataset to create a custom download.
- If you land on the download preview page with the spinner is visible then the HTML element id='excel-file' should have the attribute aria-hidden='true'
- If you land on the download preview page and the file is available to download immediately then the HTML element id='excel-file' should not have the attribute aria-hidden set

### Who can review

Anyone but me
