### PR TITLE
Fix - date picker colour contrast

### DIFF
--- a/scss/components/_date-picker.scss
+++ b/scss/components/_date-picker.scss
@@ -1,6 +1,6 @@
 .datepicker {
     background-color: $ship-grey;
-    color: $iron-light;
+    color: $grey5;
     padding: ($baseline * 3) $col;
     margin-top: ($baseline * 2);
     position: absolute;


### PR DESCRIPTION
### What
Update the font colour contrast for the date picker

### How to review
1. Load a page with the date picker
1. See that the colour contrast is low for elements of the date picker (I used "Color contrast checker" firefox addon)
1. Switch to this branch
1. See that this is resolved

### Who can review
Anyone but me
