### PR TITLE
Fix - Expand/collapse arrow overlapping

### DIFF
--- a/scss/components/_show-and-hide.scss
+++ b/scss/components/_show-and-hide.scss
@@ -14,7 +14,7 @@
             text-align: left;
             background-color: transparent;
             border: none;
-            padding: ($baseline * 2) $col ($baseline * 2) 0;
+            padding: ($baseline * 2) 56px ($baseline * 2) 0;
             //padding: 3px 0 5px 0; //This should keep the text for the button on grid
             line-height: inherit;
 


### PR DESCRIPTION
### What
Give enough space for the expand/collapse arrow.

### How to review
1. Visit a page with expand collapse boxes e.g.`timeseries_dataset`, `dataset_landing_page`, `release`, `publication`
1. See that if the content is long on at any viewport size it overlaps the arrow
1. Switch to this branch
1. See that it no longer overlaps

### Who can review
Anyone but me
