### PR TITLE
Fix - Responsiveness of filtered/unfiltered timeseries download

### DIFF
--- a/scss/components/_chart-area.scss
+++ b/scss/components/_chart-area.scss
@@ -115,26 +115,29 @@
         }
     }
 
+    &__radiogroup {
+        display: flex;
+    }
+
     &__controls__download {
         background-color: $nevada;
         margin-top: ($baseline * 2);
         position: relative;
+        width: 100%;
+        max-width: ($col * 22);
 
         &--unfiltered {
-
             &:before {
                 @include triangle(15px, $nevada, true);
-                left: 75px;
-
+                left: calc(25% - 15px);
             }
+
         }
 
         &--filtered {
-
             &:before {
-                //@extend .controls__download__arrow;
                 @include triangle(15px, $nevada, true);
-                right: 75px;
+                right: calc(25% - 15px);
             }
         }
     }

--- a/scss/elements/_buttons.scss
+++ b/scss/elements/_buttons.scss
@@ -172,22 +172,19 @@ button {
     }
 
     &--chart-control {
-        width: ($col * 4);
+        width: 50%;
+        max-width: ($col * 6);
         padding: 0;
         font-size: 12px;
         //position: relative;
         //overflow: hidden;
 
-        @include breakpoint(lg) {
-            width: ($col * 6);
-        }
-
         &--all {
-            width: ($col * 5);
+            max-width: ($col * 5);
         }
 
         &--download {
-            width: ($col * 11)
+            max-width: ($col * 11)
         }
 
     }


### PR DESCRIPTION
### What
Fix reflow issue on filtered/unfiltered timeseries download

### How to review
1. Visit a timeseries page
1. See that at small and extra small viewports then the arrows below are in the wrong position.
1. Check out this branch and babbage branch `fix/reflow-filter-unfiltered`
1. See that the issues are resolved.

### Who can review
Anyone but me