### PR TITLE
Fix/mobile menu screenreaders

### DIFF
--- a/js/app/nav.js
+++ b/js/app/nav.js
@@ -2,6 +2,11 @@ function toggleSubnav(element) {
     element
         .toggleClass('js-expandable-active')
         .find('.js-expandable__content').toggleClass('js-nav-hidden');
+    toggleAriaHidden(element.find('a:first'));
+}
+
+function toggleAriaHidden(element) {
+    element.attr('aria-expanded', element.attr('aria-expanded') === 'false');
 }
 
 function expandSubnav(element) {
@@ -96,7 +101,7 @@ function clonePrimaryItems() {
         $('.js-expandable').each(function () {
             var $this = $(this),
                 $thisHref = $this.find('a:first').attr('href'),
-                $thisText = $this.find('a:first').html(),
+                $thisText = $this.find('.submenu-title').html(),
                 $childList = $this.find('.js-expandable__content'),
                 $newLink = '<a class="primary-nav__child-link" href="' + $thisHref + '">' + $thisText + '</a>',
                 $newItem = '<li class="primary-nav__child-item js-nav__duplicate js-expandable__child">' + $newLink + '</li>';

--- a/scss/components/_header.scss
+++ b/scss/components/_header.scss
@@ -277,7 +277,10 @@
 //Add plus symbol - class used for JS too
 .js-expandable {
     @include breakpoint(sm) {
-        & > a {
+        & > a > .expansion-indicator {
+            display: initial;
+            visibility: initial;
+
             &:before {
                 position: absolute;
                 color: $iron-light;
@@ -292,9 +295,10 @@
         }
 
         &-active {
-            & > a {
+            & > a  > .expansion-indicator {
                 &:before {
-                    content: '';
+                    content: '-';
+                    padding-left: 5px;
                 }
             }
         }


### PR DESCRIPTION
### What

Screen readers (particularly on mobile) were picking up the '+' as a separate link. Added a slightly hacky patch to improve this until the new nav is implemented

### How to review

(Main focus is on iPhone voiceover)

- Using a screen reader on a mobile device.
- Go to any page and open the menu.
- Navigate to the first expansion toggle in the menu.
- You should not be able to navigate to the '+'.
- The screen reader should announce the name of the sub menu followed by 'sub menu toggle' and that it is collapsed.
- Expand the sub menu and the screen reader should announce the sub menu is now expanded.
- Navigate to the first item in the sub menu, the screen reader should announce the title of the menu item only.

### Who can review

Anyone but me.
