### PR TITLE
Fix - Reflow - Overflow scroll with shadows

### DIFF
--- a/js/app/scrollable-container.js
+++ b/js/app/scrollable-container.js
@@ -1,4 +1,3 @@
-'use strict';
 $(function () {
     function showHideShadows(element) {
         var scrollLeft = element.scrollLeft;
@@ -21,7 +20,8 @@ $(function () {
     }
 
     var observer = new ResizeObserver(function (entries) {
-        for (entry of entries) {
+        for (var i = 0; i < entries.length; ++i) {
+            var entry = entries[i];
             var container = entry.target;
             var $container = $(container);
             var hasOverflow = container.scrollWidth > $container.width();

--- a/js/app/scrollable-container.js
+++ b/js/app/scrollable-container.js
@@ -1,0 +1,20 @@
+'use strict';
+$(function () {
+    var observer = new ResizeObserver(function (entries) {
+        for (entry of entries) {
+            var container = entry.target;
+            var $container = $(container);
+            var hasOverflow = container.scrollWidth > $container.width();
+            if (!hasOverflow) {
+                $container.removeClass('scrollable-container__overflow');
+                continue;
+            }
+            console.log(entry.contentRect.height + 10);
+            $container.addClass('scrollable-container__overflow');
+        }
+    });
+    $('.scrollable-container').each(function (i, container) {
+        $(container).wrap('<div class="scrollable-container__parent"></div>');
+        observer.observe(container)
+    });
+});

--- a/js/app/scrollable-container.js
+++ b/js/app/scrollable-container.js
@@ -11,7 +11,8 @@ $(function () {
         }
 
         var scrollLeftMax = element.scrollWidth - element.clientWidth;
-        if (scrollLeft === scrollLeftMax) {
+        // Can be greater due to iOS overscroll
+        if (scrollLeft >= scrollLeftMax) {
             $element.removeClass('scroll-container__right-shadow')
         }
         else {

--- a/js/app/scrollable-container.js
+++ b/js/app/scrollable-container.js
@@ -1,5 +1,24 @@
 'use strict';
 $(function () {
+    function showHideShadows(element) {
+        var scrollLeft = element.scrollLeft;
+        var $element = $(element);
+        if (scrollLeft > 0) {
+            $element.addClass('scroll-container__left-shadow')
+        }
+        else {
+            $element.removeClass('scroll-container__left-shadow')
+        }
+
+        var scrollLeftMax = element.scrollWidth - element.clientWidth;
+        if (scrollLeft === scrollLeftMax) {
+            $element.removeClass('scroll-container__right-shadow')
+        }
+        else {
+            $element.addClass('scroll-container__right-shadow')
+        }
+    }
+
     var observer = new ResizeObserver(function (entries) {
         for (entry of entries) {
             var container = entry.target;
@@ -7,10 +26,14 @@ $(function () {
             var hasOverflow = container.scrollWidth > $container.width();
             if (!hasOverflow) {
                 $container.removeClass('scrollable-container__overflow');
+                $container.off('scroll');
                 continue;
             }
-            console.log(entry.contentRect.height + 10);
             $container.addClass('scrollable-container__overflow');
+            showHideShadows(container);
+            $container.on('scroll', function (event) {
+                showHideShadows(event.target)
+            });
         }
     });
     $('.scrollable-container').each(function (i, container) {

--- a/js/thirdparty/resize-observer-polyfill.js
+++ b/js/thirdparty/resize-observer-polyfill.js
@@ -1,0 +1,936 @@
+(function (global, factory) {
+    typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
+    typeof define === 'function' && define.amd ? define(factory) :
+    (global.ResizeObserver = factory());
+}(this, (function () { 'use strict';
+
+    /**
+     * A collection of shims that provide minimal functionality of the ES6 collections.
+     *
+     * These implementations are not meant to be used outside of the ResizeObserver
+     * modules as they cover only a limited range of use cases.
+     */
+    /* eslint-disable require-jsdoc, valid-jsdoc */
+    var MapShim = (function () {
+        if (typeof Map !== 'undefined') {
+            return Map;
+        }
+        /**
+         * Returns index in provided array that matches the specified key.
+         *
+         * @param {Array<Array>} arr
+         * @param {*} key
+         * @returns {number}
+         */
+        function getIndex(arr, key) {
+            var result = -1;
+            arr.some(function (entry, index) {
+                if (entry[0] === key) {
+                    result = index;
+                    return true;
+                }
+                return false;
+            });
+            return result;
+        }
+        return /** @class */ (function () {
+            function class_1() {
+                this.__entries__ = [];
+            }
+            Object.defineProperty(class_1.prototype, "size", {
+                /**
+                 * @returns {boolean}
+                 */
+                get: function () {
+                    return this.__entries__.length;
+                },
+                enumerable: true,
+                configurable: true
+            });
+            /**
+             * @param {*} key
+             * @returns {*}
+             */
+            class_1.prototype.get = function (key) {
+                var index = getIndex(this.__entries__, key);
+                var entry = this.__entries__[index];
+                return entry && entry[1];
+            };
+            /**
+             * @param {*} key
+             * @param {*} value
+             * @returns {void}
+             */
+            class_1.prototype.set = function (key, value) {
+                var index = getIndex(this.__entries__, key);
+                if (~index) {
+                    this.__entries__[index][1] = value;
+                }
+                else {
+                    this.__entries__.push([key, value]);
+                }
+            };
+            /**
+             * @param {*} key
+             * @returns {void}
+             */
+            class_1.prototype.delete = function (key) {
+                var entries = this.__entries__;
+                var index = getIndex(entries, key);
+                if (~index) {
+                    entries.splice(index, 1);
+                }
+            };
+            /**
+             * @param {*} key
+             * @returns {void}
+             */
+            class_1.prototype.has = function (key) {
+                return !!~getIndex(this.__entries__, key);
+            };
+            /**
+             * @returns {void}
+             */
+            class_1.prototype.clear = function () {
+                this.__entries__.splice(0);
+            };
+            /**
+             * @param {Function} callback
+             * @param {*} [ctx=null]
+             * @returns {void}
+             */
+            class_1.prototype.forEach = function (callback, ctx) {
+                if (ctx === void 0) { ctx = null; }
+                for (var _i = 0, _a = this.__entries__; _i < _a.length; _i++) {
+                    var entry = _a[_i];
+                    callback.call(ctx, entry[1], entry[0]);
+                }
+            };
+            return class_1;
+        }());
+    })();
+
+    /**
+     * Detects whether window and document objects are available in current environment.
+     */
+    var isBrowser = typeof window !== 'undefined' && typeof document !== 'undefined' && window.document === document;
+
+    // Returns global object of a current environment.
+    var global$1 = (function () {
+        if (typeof global !== 'undefined' && global.Math === Math) {
+            return global;
+        }
+        if (typeof self !== 'undefined' && self.Math === Math) {
+            return self;
+        }
+        if (typeof window !== 'undefined' && window.Math === Math) {
+            return window;
+        }
+        // eslint-disable-next-line no-new-func
+        return Function('return this')();
+    })();
+
+    /**
+     * A shim for the requestAnimationFrame which falls back to the setTimeout if
+     * first one is not supported.
+     *
+     * @returns {number} Requests' identifier.
+     */
+    var requestAnimationFrame$1 = (function () {
+        if (typeof requestAnimationFrame === 'function') {
+            // It's required to use a bounded function because IE sometimes throws
+            // an "Invalid calling object" error if rAF is invoked without the global
+            // object on the left hand side.
+            return requestAnimationFrame.bind(global$1);
+        }
+        return function (callback) { return setTimeout(function () { return callback(Date.now()); }, 1000 / 60); };
+    })();
+
+    // Defines minimum timeout before adding a trailing call.
+    var trailingTimeout = 2;
+    /**
+     * Creates a wrapper function which ensures that provided callback will be
+     * invoked only once during the specified delay period.
+     *
+     * @param {Function} callback - Function to be invoked after the delay period.
+     * @param {number} delay - Delay after which to invoke callback.
+     * @returns {Function}
+     */
+    function throttle (callback, delay) {
+        var leadingCall = false, trailingCall = false, lastCallTime = 0;
+        /**
+         * Invokes the original callback function and schedules new invocation if
+         * the "proxy" was called during current request.
+         *
+         * @returns {void}
+         */
+        function resolvePending() {
+            if (leadingCall) {
+                leadingCall = false;
+                callback();
+            }
+            if (trailingCall) {
+                proxy();
+            }
+        }
+        /**
+         * Callback invoked after the specified delay. It will further postpone
+         * invocation of the original function delegating it to the
+         * requestAnimationFrame.
+         *
+         * @returns {void}
+         */
+        function timeoutCallback() {
+            requestAnimationFrame$1(resolvePending);
+        }
+        /**
+         * Schedules invocation of the original function.
+         *
+         * @returns {void}
+         */
+        function proxy() {
+            var timeStamp = Date.now();
+            if (leadingCall) {
+                // Reject immediately following calls.
+                if (timeStamp - lastCallTime < trailingTimeout) {
+                    return;
+                }
+                // Schedule new call to be in invoked when the pending one is resolved.
+                // This is important for "transitions" which never actually start
+                // immediately so there is a chance that we might miss one if change
+                // happens amids the pending invocation.
+                trailingCall = true;
+            }
+            else {
+                leadingCall = true;
+                trailingCall = false;
+                setTimeout(timeoutCallback, delay);
+            }
+            lastCallTime = timeStamp;
+        }
+        return proxy;
+    }
+
+    // Minimum delay before invoking the update of observers.
+    var REFRESH_DELAY = 20;
+    // A list of substrings of CSS properties used to find transition events that
+    // might affect dimensions of observed elements.
+    var transitionKeys = ['top', 'right', 'bottom', 'left', 'width', 'height', 'size', 'weight'];
+    // Check if MutationObserver is available.
+    var mutationObserverSupported = typeof MutationObserver !== 'undefined';
+    /**
+     * Singleton controller class which handles updates of ResizeObserver instances.
+     */
+    var ResizeObserverController = /** @class */ (function () {
+        /**
+         * Creates a new instance of ResizeObserverController.
+         *
+         * @private
+         */
+        function ResizeObserverController() {
+            /**
+             * Indicates whether DOM listeners have been added.
+             *
+             * @private {boolean}
+             */
+            this.connected_ = false;
+            /**
+             * Tells that controller has subscribed for Mutation Events.
+             *
+             * @private {boolean}
+             */
+            this.mutationEventsAdded_ = false;
+            /**
+             * Keeps reference to the instance of MutationObserver.
+             *
+             * @private {MutationObserver}
+             */
+            this.mutationsObserver_ = null;
+            /**
+             * A list of connected observers.
+             *
+             * @private {Array<ResizeObserverSPI>}
+             */
+            this.observers_ = [];
+            this.onTransitionEnd_ = this.onTransitionEnd_.bind(this);
+            this.refresh = throttle(this.refresh.bind(this), REFRESH_DELAY);
+        }
+        /**
+         * Adds observer to observers list.
+         *
+         * @param {ResizeObserverSPI} observer - Observer to be added.
+         * @returns {void}
+         */
+        ResizeObserverController.prototype.addObserver = function (observer) {
+            if (!~this.observers_.indexOf(observer)) {
+                this.observers_.push(observer);
+            }
+            // Add listeners if they haven't been added yet.
+            if (!this.connected_) {
+                this.connect_();
+            }
+        };
+        /**
+         * Removes observer from observers list.
+         *
+         * @param {ResizeObserverSPI} observer - Observer to be removed.
+         * @returns {void}
+         */
+        ResizeObserverController.prototype.removeObserver = function (observer) {
+            var observers = this.observers_;
+            var index = observers.indexOf(observer);
+            // Remove observer if it's present in registry.
+            if (~index) {
+                observers.splice(index, 1);
+            }
+            // Remove listeners if controller has no connected observers.
+            if (!observers.length && this.connected_) {
+                this.disconnect_();
+            }
+        };
+        /**
+         * Invokes the update of observers. It will continue running updates insofar
+         * it detects changes.
+         *
+         * @returns {void}
+         */
+        ResizeObserverController.prototype.refresh = function () {
+            var changesDetected = this.updateObservers_();
+            // Continue running updates if changes have been detected as there might
+            // be future ones caused by CSS transitions.
+            if (changesDetected) {
+                this.refresh();
+            }
+        };
+        /**
+         * Updates every observer from observers list and notifies them of queued
+         * entries.
+         *
+         * @private
+         * @returns {boolean} Returns "true" if any observer has detected changes in
+         *      dimensions of it's elements.
+         */
+        ResizeObserverController.prototype.updateObservers_ = function () {
+            // Collect observers that have active observations.
+            var activeObservers = this.observers_.filter(function (observer) {
+                return observer.gatherActive(), observer.hasActive();
+            });
+            // Deliver notifications in a separate cycle in order to avoid any
+            // collisions between observers, e.g. when multiple instances of
+            // ResizeObserver are tracking the same element and the callback of one
+            // of them changes content dimensions of the observed target. Sometimes
+            // this may result in notifications being blocked for the rest of observers.
+            activeObservers.forEach(function (observer) { return observer.broadcastActive(); });
+            return activeObservers.length > 0;
+        };
+        /**
+         * Initializes DOM listeners.
+         *
+         * @private
+         * @returns {void}
+         */
+        ResizeObserverController.prototype.connect_ = function () {
+            // Do nothing if running in a non-browser environment or if listeners
+            // have been already added.
+            if (!isBrowser || this.connected_) {
+                return;
+            }
+            // Subscription to the "Transitionend" event is used as a workaround for
+            // delayed transitions. This way it's possible to capture at least the
+            // final state of an element.
+            document.addEventListener('transitionend', this.onTransitionEnd_);
+            window.addEventListener('resize', this.refresh);
+            if (mutationObserverSupported) {
+                this.mutationsObserver_ = new MutationObserver(this.refresh);
+                this.mutationsObserver_.observe(document, {
+                    attributes: true,
+                    childList: true,
+                    characterData: true,
+                    subtree: true
+                });
+            }
+            else {
+                document.addEventListener('DOMSubtreeModified', this.refresh);
+                this.mutationEventsAdded_ = true;
+            }
+            this.connected_ = true;
+        };
+        /**
+         * Removes DOM listeners.
+         *
+         * @private
+         * @returns {void}
+         */
+        ResizeObserverController.prototype.disconnect_ = function () {
+            // Do nothing if running in a non-browser environment or if listeners
+            // have been already removed.
+            if (!isBrowser || !this.connected_) {
+                return;
+            }
+            document.removeEventListener('transitionend', this.onTransitionEnd_);
+            window.removeEventListener('resize', this.refresh);
+            if (this.mutationsObserver_) {
+                this.mutationsObserver_.disconnect();
+            }
+            if (this.mutationEventsAdded_) {
+                document.removeEventListener('DOMSubtreeModified', this.refresh);
+            }
+            this.mutationsObserver_ = null;
+            this.mutationEventsAdded_ = false;
+            this.connected_ = false;
+        };
+        /**
+         * "Transitionend" event handler.
+         *
+         * @private
+         * @param {TransitionEvent} event
+         * @returns {void}
+         */
+        ResizeObserverController.prototype.onTransitionEnd_ = function (_a) {
+            var _b = _a.propertyName, propertyName = _b === void 0 ? '' : _b;
+            // Detect whether transition may affect dimensions of an element.
+            var isReflowProperty = transitionKeys.some(function (key) {
+                return !!~propertyName.indexOf(key);
+            });
+            if (isReflowProperty) {
+                this.refresh();
+            }
+        };
+        /**
+         * Returns instance of the ResizeObserverController.
+         *
+         * @returns {ResizeObserverController}
+         */
+        ResizeObserverController.getInstance = function () {
+            if (!this.instance_) {
+                this.instance_ = new ResizeObserverController();
+            }
+            return this.instance_;
+        };
+        /**
+         * Holds reference to the controller's instance.
+         *
+         * @private {ResizeObserverController}
+         */
+        ResizeObserverController.instance_ = null;
+        return ResizeObserverController;
+    }());
+
+    /**
+     * Defines non-writable/enumerable properties of the provided target object.
+     *
+     * @param {Object} target - Object for which to define properties.
+     * @param {Object} props - Properties to be defined.
+     * @returns {Object} Target object.
+     */
+    var defineConfigurable = (function (target, props) {
+        for (var _i = 0, _a = Object.keys(props); _i < _a.length; _i++) {
+            var key = _a[_i];
+            Object.defineProperty(target, key, {
+                value: props[key],
+                enumerable: false,
+                writable: false,
+                configurable: true
+            });
+        }
+        return target;
+    });
+
+    /**
+     * Returns the global object associated with provided element.
+     *
+     * @param {Object} target
+     * @returns {Object}
+     */
+    var getWindowOf = (function (target) {
+        // Assume that the element is an instance of Node, which means that it
+        // has the "ownerDocument" property from which we can retrieve a
+        // corresponding global object.
+        var ownerGlobal = target && target.ownerDocument && target.ownerDocument.defaultView;
+        // Return the local global object if it's not possible extract one from
+        // provided element.
+        return ownerGlobal || global$1;
+    });
+
+    // Placeholder of an empty content rectangle.
+    var emptyRect = createRectInit(0, 0, 0, 0);
+    /**
+     * Converts provided string to a number.
+     *
+     * @param {number|string} value
+     * @returns {number}
+     */
+    function toFloat(value) {
+        return parseFloat(value) || 0;
+    }
+    /**
+     * Extracts borders size from provided styles.
+     *
+     * @param {CSSStyleDeclaration} styles
+     * @param {...string} positions - Borders positions (top, right, ...)
+     * @returns {number}
+     */
+    function getBordersSize(styles) {
+        var positions = [];
+        for (var _i = 1; _i < arguments.length; _i++) {
+            positions[_i - 1] = arguments[_i];
+        }
+        return positions.reduce(function (size, position) {
+            var value = styles['border-' + position + '-width'];
+            return size + toFloat(value);
+        }, 0);
+    }
+    /**
+     * Extracts paddings sizes from provided styles.
+     *
+     * @param {CSSStyleDeclaration} styles
+     * @returns {Object} Paddings box.
+     */
+    function getPaddings(styles) {
+        var positions = ['top', 'right', 'bottom', 'left'];
+        var paddings = {};
+        for (var _i = 0, positions_1 = positions; _i < positions_1.length; _i++) {
+            var position = positions_1[_i];
+            var value = styles['padding-' + position];
+            paddings[position] = toFloat(value);
+        }
+        return paddings;
+    }
+    /**
+     * Calculates content rectangle of provided SVG element.
+     *
+     * @param {SVGGraphicsElement} target - Element content rectangle of which needs
+     *      to be calculated.
+     * @returns {DOMRectInit}
+     */
+    function getSVGContentRect(target) {
+        var bbox = target.getBBox();
+        return createRectInit(0, 0, bbox.width, bbox.height);
+    }
+    /**
+     * Calculates content rectangle of provided HTMLElement.
+     *
+     * @param {HTMLElement} target - Element for which to calculate the content rectangle.
+     * @returns {DOMRectInit}
+     */
+    function getHTMLElementContentRect(target) {
+        // Client width & height properties can't be
+        // used exclusively as they provide rounded values.
+        var clientWidth = target.clientWidth, clientHeight = target.clientHeight;
+        // By this condition we can catch all non-replaced inline, hidden and
+        // detached elements. Though elements with width & height properties less
+        // than 0.5 will be discarded as well.
+        //
+        // Without it we would need to implement separate methods for each of
+        // those cases and it's not possible to perform a precise and performance
+        // effective test for hidden elements. E.g. even jQuery's ':visible' filter
+        // gives wrong results for elements with width & height less than 0.5.
+        if (!clientWidth && !clientHeight) {
+            return emptyRect;
+        }
+        var styles = getWindowOf(target).getComputedStyle(target);
+        var paddings = getPaddings(styles);
+        var horizPad = paddings.left + paddings.right;
+        var vertPad = paddings.top + paddings.bottom;
+        // Computed styles of width & height are being used because they are the
+        // only dimensions available to JS that contain non-rounded values. It could
+        // be possible to utilize the getBoundingClientRect if only it's data wasn't
+        // affected by CSS transformations let alone paddings, borders and scroll bars.
+        var width = toFloat(styles.width), height = toFloat(styles.height);
+        // Width & height include paddings and borders when the 'border-box' box
+        // model is applied (except for IE).
+        if (styles.boxSizing === 'border-box') {
+            // Following conditions are required to handle Internet Explorer which
+            // doesn't include paddings and borders to computed CSS dimensions.
+            //
+            // We can say that if CSS dimensions + paddings are equal to the "client"
+            // properties then it's either IE, and thus we don't need to subtract
+            // anything, or an element merely doesn't have paddings/borders styles.
+            if (Math.round(width + horizPad) !== clientWidth) {
+                width -= getBordersSize(styles, 'left', 'right') + horizPad;
+            }
+            if (Math.round(height + vertPad) !== clientHeight) {
+                height -= getBordersSize(styles, 'top', 'bottom') + vertPad;
+            }
+        }
+        // Following steps can't be applied to the document's root element as its
+        // client[Width/Height] properties represent viewport area of the window.
+        // Besides, it's as well not necessary as the <html> itself neither has
+        // rendered scroll bars nor it can be clipped.
+        if (!isDocumentElement(target)) {
+            // In some browsers (only in Firefox, actually) CSS width & height
+            // include scroll bars size which can be removed at this step as scroll
+            // bars are the only difference between rounded dimensions + paddings
+            // and "client" properties, though that is not always true in Chrome.
+            var vertScrollbar = Math.round(width + horizPad) - clientWidth;
+            var horizScrollbar = Math.round(height + vertPad) - clientHeight;
+            // Chrome has a rather weird rounding of "client" properties.
+            // E.g. for an element with content width of 314.2px it sometimes gives
+            // the client width of 315px and for the width of 314.7px it may give
+            // 314px. And it doesn't happen all the time. So just ignore this delta
+            // as a non-relevant.
+            if (Math.abs(vertScrollbar) !== 1) {
+                width -= vertScrollbar;
+            }
+            if (Math.abs(horizScrollbar) !== 1) {
+                height -= horizScrollbar;
+            }
+        }
+        return createRectInit(paddings.left, paddings.top, width, height);
+    }
+    /**
+     * Checks whether provided element is an instance of the SVGGraphicsElement.
+     *
+     * @param {Element} target - Element to be checked.
+     * @returns {boolean}
+     */
+    var isSVGGraphicsElement = (function () {
+        // Some browsers, namely IE and Edge, don't have the SVGGraphicsElement
+        // interface.
+        if (typeof SVGGraphicsElement !== 'undefined') {
+            return function (target) { return target instanceof getWindowOf(target).SVGGraphicsElement; };
+        }
+        // If it's so, then check that element is at least an instance of the
+        // SVGElement and that it has the "getBBox" method.
+        // eslint-disable-next-line no-extra-parens
+        return function (target) { return (target instanceof getWindowOf(target).SVGElement &&
+            typeof target.getBBox === 'function'); };
+    })();
+    /**
+     * Checks whether provided element is a document element (<html>).
+     *
+     * @param {Element} target - Element to be checked.
+     * @returns {boolean}
+     */
+    function isDocumentElement(target) {
+        return target === getWindowOf(target).document.documentElement;
+    }
+    /**
+     * Calculates an appropriate content rectangle for provided html or svg element.
+     *
+     * @param {Element} target - Element content rectangle of which needs to be calculated.
+     * @returns {DOMRectInit}
+     */
+    function getContentRect(target) {
+        if (!isBrowser) {
+            return emptyRect;
+        }
+        if (isSVGGraphicsElement(target)) {
+            return getSVGContentRect(target);
+        }
+        return getHTMLElementContentRect(target);
+    }
+    /**
+     * Creates rectangle with an interface of the DOMRectReadOnly.
+     * Spec: https://drafts.fxtf.org/geometry/#domrectreadonly
+     *
+     * @param {DOMRectInit} rectInit - Object with rectangle's x/y coordinates and dimensions.
+     * @returns {DOMRectReadOnly}
+     */
+    function createReadOnlyRect(_a) {
+        var x = _a.x, y = _a.y, width = _a.width, height = _a.height;
+        // If DOMRectReadOnly is available use it as a prototype for the rectangle.
+        var Constr = typeof DOMRectReadOnly !== 'undefined' ? DOMRectReadOnly : Object;
+        var rect = Object.create(Constr.prototype);
+        // Rectangle's properties are not writable and non-enumerable.
+        defineConfigurable(rect, {
+            x: x, y: y, width: width, height: height,
+            top: y,
+            right: x + width,
+            bottom: height + y,
+            left: x
+        });
+        return rect;
+    }
+    /**
+     * Creates DOMRectInit object based on the provided dimensions and the x/y coordinates.
+     * Spec: https://drafts.fxtf.org/geometry/#dictdef-domrectinit
+     *
+     * @param {number} x - X coordinate.
+     * @param {number} y - Y coordinate.
+     * @param {number} width - Rectangle's width.
+     * @param {number} height - Rectangle's height.
+     * @returns {DOMRectInit}
+     */
+    function createRectInit(x, y, width, height) {
+        return { x: x, y: y, width: width, height: height };
+    }
+
+    /**
+     * Class that is responsible for computations of the content rectangle of
+     * provided DOM element and for keeping track of it's changes.
+     */
+    var ResizeObservation = /** @class */ (function () {
+        /**
+         * Creates an instance of ResizeObservation.
+         *
+         * @param {Element} target - Element to be observed.
+         */
+        function ResizeObservation(target) {
+            /**
+             * Broadcasted width of content rectangle.
+             *
+             * @type {number}
+             */
+            this.broadcastWidth = 0;
+            /**
+             * Broadcasted height of content rectangle.
+             *
+             * @type {number}
+             */
+            this.broadcastHeight = 0;
+            /**
+             * Reference to the last observed content rectangle.
+             *
+             * @private {DOMRectInit}
+             */
+            this.contentRect_ = createRectInit(0, 0, 0, 0);
+            this.target = target;
+        }
+        /**
+         * Updates content rectangle and tells whether it's width or height properties
+         * have changed since the last broadcast.
+         *
+         * @returns {boolean}
+         */
+        ResizeObservation.prototype.isActive = function () {
+            var rect = getContentRect(this.target);
+            this.contentRect_ = rect;
+            return (rect.width !== this.broadcastWidth ||
+                rect.height !== this.broadcastHeight);
+        };
+        /**
+         * Updates 'broadcastWidth' and 'broadcastHeight' properties with a data
+         * from the corresponding properties of the last observed content rectangle.
+         *
+         * @returns {DOMRectInit} Last observed content rectangle.
+         */
+        ResizeObservation.prototype.broadcastRect = function () {
+            var rect = this.contentRect_;
+            this.broadcastWidth = rect.width;
+            this.broadcastHeight = rect.height;
+            return rect;
+        };
+        return ResizeObservation;
+    }());
+
+    var ResizeObserverEntry = /** @class */ (function () {
+        /**
+         * Creates an instance of ResizeObserverEntry.
+         *
+         * @param {Element} target - Element that is being observed.
+         * @param {DOMRectInit} rectInit - Data of the element's content rectangle.
+         */
+        function ResizeObserverEntry(target, rectInit) {
+            var contentRect = createReadOnlyRect(rectInit);
+            // According to the specification following properties are not writable
+            // and are also not enumerable in the native implementation.
+            //
+            // Property accessors are not being used as they'd require to define a
+            // private WeakMap storage which may cause memory leaks in browsers that
+            // don't support this type of collections.
+            defineConfigurable(this, { target: target, contentRect: contentRect });
+        }
+        return ResizeObserverEntry;
+    }());
+
+    var ResizeObserverSPI = /** @class */ (function () {
+        /**
+         * Creates a new instance of ResizeObserver.
+         *
+         * @param {ResizeObserverCallback} callback - Callback function that is invoked
+         *      when one of the observed elements changes it's content dimensions.
+         * @param {ResizeObserverController} controller - Controller instance which
+         *      is responsible for the updates of observer.
+         * @param {ResizeObserver} callbackCtx - Reference to the public
+         *      ResizeObserver instance which will be passed to callback function.
+         */
+        function ResizeObserverSPI(callback, controller, callbackCtx) {
+            /**
+             * Collection of resize observations that have detected changes in dimensions
+             * of elements.
+             *
+             * @private {Array<ResizeObservation>}
+             */
+            this.activeObservations_ = [];
+            /**
+             * Registry of the ResizeObservation instances.
+             *
+             * @private {Map<Element, ResizeObservation>}
+             */
+            this.observations_ = new MapShim();
+            if (typeof callback !== 'function') {
+                throw new TypeError('The callback provided as parameter 1 is not a function.');
+            }
+            this.callback_ = callback;
+            this.controller_ = controller;
+            this.callbackCtx_ = callbackCtx;
+        }
+        /**
+         * Starts observing provided element.
+         *
+         * @param {Element} target - Element to be observed.
+         * @returns {void}
+         */
+        ResizeObserverSPI.prototype.observe = function (target) {
+            if (!arguments.length) {
+                throw new TypeError('1 argument required, but only 0 present.');
+            }
+            // Do nothing if current environment doesn't have the Element interface.
+            if (typeof Element === 'undefined' || !(Element instanceof Object)) {
+                return;
+            }
+            if (!(target instanceof getWindowOf(target).Element)) {
+                throw new TypeError('parameter 1 is not of type "Element".');
+            }
+            var observations = this.observations_;
+            // Do nothing if element is already being observed.
+            if (observations.has(target)) {
+                return;
+            }
+            observations.set(target, new ResizeObservation(target));
+            this.controller_.addObserver(this);
+            // Force the update of observations.
+            this.controller_.refresh();
+        };
+        /**
+         * Stops observing provided element.
+         *
+         * @param {Element} target - Element to stop observing.
+         * @returns {void}
+         */
+        ResizeObserverSPI.prototype.unobserve = function (target) {
+            if (!arguments.length) {
+                throw new TypeError('1 argument required, but only 0 present.');
+            }
+            // Do nothing if current environment doesn't have the Element interface.
+            if (typeof Element === 'undefined' || !(Element instanceof Object)) {
+                return;
+            }
+            if (!(target instanceof getWindowOf(target).Element)) {
+                throw new TypeError('parameter 1 is not of type "Element".');
+            }
+            var observations = this.observations_;
+            // Do nothing if element is not being observed.
+            if (!observations.has(target)) {
+                return;
+            }
+            observations.delete(target);
+            if (!observations.size) {
+                this.controller_.removeObserver(this);
+            }
+        };
+        /**
+         * Stops observing all elements.
+         *
+         * @returns {void}
+         */
+        ResizeObserverSPI.prototype.disconnect = function () {
+            this.clearActive();
+            this.observations_.clear();
+            this.controller_.removeObserver(this);
+        };
+        /**
+         * Collects observation instances the associated element of which has changed
+         * it's content rectangle.
+         *
+         * @returns {void}
+         */
+        ResizeObserverSPI.prototype.gatherActive = function () {
+            var _this = this;
+            this.clearActive();
+            this.observations_.forEach(function (observation) {
+                if (observation.isActive()) {
+                    _this.activeObservations_.push(observation);
+                }
+            });
+        };
+        /**
+         * Invokes initial callback function with a list of ResizeObserverEntry
+         * instances collected from active resize observations.
+         *
+         * @returns {void}
+         */
+        ResizeObserverSPI.prototype.broadcastActive = function () {
+            // Do nothing if observer doesn't have active observations.
+            if (!this.hasActive()) {
+                return;
+            }
+            var ctx = this.callbackCtx_;
+            // Create ResizeObserverEntry instance for every active observation.
+            var entries = this.activeObservations_.map(function (observation) {
+                return new ResizeObserverEntry(observation.target, observation.broadcastRect());
+            });
+            this.callback_.call(ctx, entries, ctx);
+            this.clearActive();
+        };
+        /**
+         * Clears the collection of active observations.
+         *
+         * @returns {void}
+         */
+        ResizeObserverSPI.prototype.clearActive = function () {
+            this.activeObservations_.splice(0);
+        };
+        /**
+         * Tells whether observer has active observations.
+         *
+         * @returns {boolean}
+         */
+        ResizeObserverSPI.prototype.hasActive = function () {
+            return this.activeObservations_.length > 0;
+        };
+        return ResizeObserverSPI;
+    }());
+
+    // Registry of internal observers. If WeakMap is not available use current shim
+    // for the Map collection as it has all required methods and because WeakMap
+    // can't be fully polyfilled anyway.
+    var observers = typeof WeakMap !== 'undefined' ? new WeakMap() : new MapShim();
+    /**
+     * ResizeObserver API. Encapsulates the ResizeObserver SPI implementation
+     * exposing only those methods and properties that are defined in the spec.
+     */
+    var ResizeObserver = /** @class */ (function () {
+        /**
+         * Creates a new instance of ResizeObserver.
+         *
+         * @param {ResizeObserverCallback} callback - Callback that is invoked when
+         *      dimensions of the observed elements change.
+         */
+        function ResizeObserver(callback) {
+            if (!(this instanceof ResizeObserver)) {
+                throw new TypeError('Cannot call a class as a function.');
+            }
+            if (!arguments.length) {
+                throw new TypeError('1 argument required, but only 0 present.');
+            }
+            var controller = ResizeObserverController.getInstance();
+            var observer = new ResizeObserverSPI(callback, controller, this);
+            observers.set(this, observer);
+        }
+        return ResizeObserver;
+    }());
+    // Expose public methods of ResizeObserver.
+    [
+        'observe',
+        'unobserve',
+        'disconnect'
+    ].forEach(function (method) {
+        ResizeObserver.prototype[method] = function () {
+            var _a;
+            return (_a = observers.get(this))[method].apply(_a, arguments);
+        };
+    });
+
+    var index = (function () {
+        // Export existing implementation if available.
+        if (typeof global$1.ResizeObserver !== 'undefined') {
+            return global$1.ResizeObserver;
+        }
+        return ResizeObserver;
+    })();
+
+    return index;
+
+})));

--- a/js/thirdparty/resize-observer-polyfill.js
+++ b/js/thirdparty/resize-observer-polyfill.js
@@ -4,933 +4,1031 @@
     (global.ResizeObserver = factory());
 }(this, (function () { 'use strict';
 
-    /**
-     * A collection of shims that provide minimal functionality of the ES6 collections.
-     *
-     * These implementations are not meant to be used outside of the ResizeObserver
-     * modules as they cover only a limited range of use cases.
-     */
-    /* eslint-disable require-jsdoc, valid-jsdoc */
-    var MapShim = (function () {
-        if (typeof Map !== 'undefined') {
-            return Map;
-        }
-        /**
-         * Returns index in provided array that matches the specified key.
-         *
-         * @param {Array<Array>} arr
-         * @param {*} key
-         * @returns {number}
-         */
-        function getIndex(arr, key) {
-            var result = -1;
-            arr.some(function (entry, index) {
-                if (entry[0] === key) {
-                    result = index;
-                    return true;
-                }
-                return false;
-            });
-            return result;
-        }
-        return /** @class */ (function () {
-            function class_1() {
-                this.__entries__ = [];
-            }
-            Object.defineProperty(class_1.prototype, "size", {
-                /**
-                 * @returns {boolean}
-                 */
-                get: function () {
-                    return this.__entries__.length;
-                },
-                enumerable: true,
-                configurable: true
-            });
-            /**
-             * @param {*} key
-             * @returns {*}
-             */
-            class_1.prototype.get = function (key) {
-                var index = getIndex(this.__entries__, key);
-                var entry = this.__entries__[index];
-                return entry && entry[1];
-            };
-            /**
-             * @param {*} key
-             * @param {*} value
-             * @returns {void}
-             */
-            class_1.prototype.set = function (key, value) {
-                var index = getIndex(this.__entries__, key);
-                if (~index) {
-                    this.__entries__[index][1] = value;
-                }
-                else {
-                    this.__entries__.push([key, value]);
-                }
-            };
-            /**
-             * @param {*} key
-             * @returns {void}
-             */
-            class_1.prototype.delete = function (key) {
-                var entries = this.__entries__;
-                var index = getIndex(entries, key);
-                if (~index) {
-                    entries.splice(index, 1);
-                }
-            };
-            /**
-             * @param {*} key
-             * @returns {void}
-             */
-            class_1.prototype.has = function (key) {
-                return !!~getIndex(this.__entries__, key);
-            };
-            /**
-             * @returns {void}
-             */
-            class_1.prototype.clear = function () {
-                this.__entries__.splice(0);
-            };
-            /**
-             * @param {Function} callback
-             * @param {*} [ctx=null]
-             * @returns {void}
-             */
-            class_1.prototype.forEach = function (callback, ctx) {
-                if (ctx === void 0) { ctx = null; }
-                for (var _i = 0, _a = this.__entries__; _i < _a.length; _i++) {
-                    var entry = _a[_i];
-                    callback.call(ctx, entry[1], entry[0]);
-                }
-            };
-            return class_1;
-        }());
-    })();
-
-    /**
-     * Detects whether window and document objects are available in current environment.
-     */
-    var isBrowser = typeof window !== 'undefined' && typeof document !== 'undefined' && window.document === document;
-
-    // Returns global object of a current environment.
-    var global$1 = (function () {
-        if (typeof global !== 'undefined' && global.Math === Math) {
-            return global;
-        }
-        if (typeof self !== 'undefined' && self.Math === Math) {
-            return self;
-        }
-        if (typeof window !== 'undefined' && window.Math === Math) {
-            return window;
-        }
-        // eslint-disable-next-line no-new-func
-        return Function('return this')();
-    })();
-
-    /**
-     * A shim for the requestAnimationFrame which falls back to the setTimeout if
-     * first one is not supported.
-     *
-     * @returns {number} Requests' identifier.
-     */
-    var requestAnimationFrame$1 = (function () {
-        if (typeof requestAnimationFrame === 'function') {
-            // It's required to use a bounded function because IE sometimes throws
-            // an "Invalid calling object" error if rAF is invoked without the global
-            // object on the left hand side.
-            return requestAnimationFrame.bind(global$1);
-        }
-        return function (callback) { return setTimeout(function () { return callback(Date.now()); }, 1000 / 60); };
-    })();
-
-    // Defines minimum timeout before adding a trailing call.
-    var trailingTimeout = 2;
-    /**
-     * Creates a wrapper function which ensures that provided callback will be
-     * invoked only once during the specified delay period.
-     *
-     * @param {Function} callback - Function to be invoked after the delay period.
-     * @param {number} delay - Delay after which to invoke callback.
-     * @returns {Function}
-     */
-    function throttle (callback, delay) {
-        var leadingCall = false, trailingCall = false, lastCallTime = 0;
-        /**
-         * Invokes the original callback function and schedules new invocation if
-         * the "proxy" was called during current request.
-         *
-         * @returns {void}
-         */
-        function resolvePending() {
-            if (leadingCall) {
-                leadingCall = false;
-                callback();
-            }
-            if (trailingCall) {
-                proxy();
-            }
-        }
-        /**
-         * Callback invoked after the specified delay. It will further postpone
-         * invocation of the original function delegating it to the
-         * requestAnimationFrame.
-         *
-         * @returns {void}
-         */
-        function timeoutCallback() {
-            requestAnimationFrame$1(resolvePending);
-        }
-        /**
-         * Schedules invocation of the original function.
-         *
-         * @returns {void}
-         */
-        function proxy() {
-            var timeStamp = Date.now();
-            if (leadingCall) {
-                // Reject immediately following calls.
-                if (timeStamp - lastCallTime < trailingTimeout) {
-                    return;
-                }
-                // Schedule new call to be in invoked when the pending one is resolved.
-                // This is important for "transitions" which never actually start
-                // immediately so there is a chance that we might miss one if change
-                // happens amids the pending invocation.
-                trailingCall = true;
-            }
-            else {
-                leadingCall = true;
-                trailingCall = false;
-                setTimeout(timeoutCallback, delay);
-            }
-            lastCallTime = timeStamp;
-        }
-        return proxy;
+/**
+ * A collection of shims that provide minimal functionality of the ES6 collections.
+ *
+ * These implementations are not meant to be used outside of the ResizeObserver
+ * modules as they cover only a limited range of use cases.
+ */
+/* eslint-disable require-jsdoc, valid-jsdoc */
+var MapShim = (function () {
+    if (typeof Map !== 'undefined') {
+        return Map;
     }
 
-    // Minimum delay before invoking the update of observers.
-    var REFRESH_DELAY = 20;
-    // A list of substrings of CSS properties used to find transition events that
-    // might affect dimensions of observed elements.
-    var transitionKeys = ['top', 'right', 'bottom', 'left', 'width', 'height', 'size', 'weight'];
-    // Check if MutationObserver is available.
-    var mutationObserverSupported = typeof MutationObserver !== 'undefined';
     /**
-     * Singleton controller class which handles updates of ResizeObserver instances.
-     */
-    var ResizeObserverController = /** @class */ (function () {
-        /**
-         * Creates a new instance of ResizeObserverController.
-         *
-         * @private
-         */
-        function ResizeObserverController() {
-            /**
-             * Indicates whether DOM listeners have been added.
-             *
-             * @private {boolean}
-             */
-            this.connected_ = false;
-            /**
-             * Tells that controller has subscribed for Mutation Events.
-             *
-             * @private {boolean}
-             */
-            this.mutationEventsAdded_ = false;
-            /**
-             * Keeps reference to the instance of MutationObserver.
-             *
-             * @private {MutationObserver}
-             */
-            this.mutationsObserver_ = null;
-            /**
-             * A list of connected observers.
-             *
-             * @private {Array<ResizeObserverSPI>}
-             */
-            this.observers_ = [];
-            this.onTransitionEnd_ = this.onTransitionEnd_.bind(this);
-            this.refresh = throttle(this.refresh.bind(this), REFRESH_DELAY);
-        }
-        /**
-         * Adds observer to observers list.
-         *
-         * @param {ResizeObserverSPI} observer - Observer to be added.
-         * @returns {void}
-         */
-        ResizeObserverController.prototype.addObserver = function (observer) {
-            if (!~this.observers_.indexOf(observer)) {
-                this.observers_.push(observer);
-            }
-            // Add listeners if they haven't been added yet.
-            if (!this.connected_) {
-                this.connect_();
-            }
-        };
-        /**
-         * Removes observer from observers list.
-         *
-         * @param {ResizeObserverSPI} observer - Observer to be removed.
-         * @returns {void}
-         */
-        ResizeObserverController.prototype.removeObserver = function (observer) {
-            var observers = this.observers_;
-            var index = observers.indexOf(observer);
-            // Remove observer if it's present in registry.
-            if (~index) {
-                observers.splice(index, 1);
-            }
-            // Remove listeners if controller has no connected observers.
-            if (!observers.length && this.connected_) {
-                this.disconnect_();
-            }
-        };
-        /**
-         * Invokes the update of observers. It will continue running updates insofar
-         * it detects changes.
-         *
-         * @returns {void}
-         */
-        ResizeObserverController.prototype.refresh = function () {
-            var changesDetected = this.updateObservers_();
-            // Continue running updates if changes have been detected as there might
-            // be future ones caused by CSS transitions.
-            if (changesDetected) {
-                this.refresh();
-            }
-        };
-        /**
-         * Updates every observer from observers list and notifies them of queued
-         * entries.
-         *
-         * @private
-         * @returns {boolean} Returns "true" if any observer has detected changes in
-         *      dimensions of it's elements.
-         */
-        ResizeObserverController.prototype.updateObservers_ = function () {
-            // Collect observers that have active observations.
-            var activeObservers = this.observers_.filter(function (observer) {
-                return observer.gatherActive(), observer.hasActive();
-            });
-            // Deliver notifications in a separate cycle in order to avoid any
-            // collisions between observers, e.g. when multiple instances of
-            // ResizeObserver are tracking the same element and the callback of one
-            // of them changes content dimensions of the observed target. Sometimes
-            // this may result in notifications being blocked for the rest of observers.
-            activeObservers.forEach(function (observer) { return observer.broadcastActive(); });
-            return activeObservers.length > 0;
-        };
-        /**
-         * Initializes DOM listeners.
-         *
-         * @private
-         * @returns {void}
-         */
-        ResizeObserverController.prototype.connect_ = function () {
-            // Do nothing if running in a non-browser environment or if listeners
-            // have been already added.
-            if (!isBrowser || this.connected_) {
-                return;
-            }
-            // Subscription to the "Transitionend" event is used as a workaround for
-            // delayed transitions. This way it's possible to capture at least the
-            // final state of an element.
-            document.addEventListener('transitionend', this.onTransitionEnd_);
-            window.addEventListener('resize', this.refresh);
-            if (mutationObserverSupported) {
-                this.mutationsObserver_ = new MutationObserver(this.refresh);
-                this.mutationsObserver_.observe(document, {
-                    attributes: true,
-                    childList: true,
-                    characterData: true,
-                    subtree: true
-                });
-            }
-            else {
-                document.addEventListener('DOMSubtreeModified', this.refresh);
-                this.mutationEventsAdded_ = true;
-            }
-            this.connected_ = true;
-        };
-        /**
-         * Removes DOM listeners.
-         *
-         * @private
-         * @returns {void}
-         */
-        ResizeObserverController.prototype.disconnect_ = function () {
-            // Do nothing if running in a non-browser environment or if listeners
-            // have been already removed.
-            if (!isBrowser || !this.connected_) {
-                return;
-            }
-            document.removeEventListener('transitionend', this.onTransitionEnd_);
-            window.removeEventListener('resize', this.refresh);
-            if (this.mutationsObserver_) {
-                this.mutationsObserver_.disconnect();
-            }
-            if (this.mutationEventsAdded_) {
-                document.removeEventListener('DOMSubtreeModified', this.refresh);
-            }
-            this.mutationsObserver_ = null;
-            this.mutationEventsAdded_ = false;
-            this.connected_ = false;
-        };
-        /**
-         * "Transitionend" event handler.
-         *
-         * @private
-         * @param {TransitionEvent} event
-         * @returns {void}
-         */
-        ResizeObserverController.prototype.onTransitionEnd_ = function (_a) {
-            var _b = _a.propertyName, propertyName = _b === void 0 ? '' : _b;
-            // Detect whether transition may affect dimensions of an element.
-            var isReflowProperty = transitionKeys.some(function (key) {
-                return !!~propertyName.indexOf(key);
-            });
-            if (isReflowProperty) {
-                this.refresh();
-            }
-        };
-        /**
-         * Returns instance of the ResizeObserverController.
-         *
-         * @returns {ResizeObserverController}
-         */
-        ResizeObserverController.getInstance = function () {
-            if (!this.instance_) {
-                this.instance_ = new ResizeObserverController();
-            }
-            return this.instance_;
-        };
-        /**
-         * Holds reference to the controller's instance.
-         *
-         * @private {ResizeObserverController}
-         */
-        ResizeObserverController.instance_ = null;
-        return ResizeObserverController;
-    }());
-
-    /**
-     * Defines non-writable/enumerable properties of the provided target object.
+     * Returns index in provided array that matches the specified key.
      *
-     * @param {Object} target - Object for which to define properties.
-     * @param {Object} props - Properties to be defined.
-     * @returns {Object} Target object.
-     */
-    var defineConfigurable = (function (target, props) {
-        for (var _i = 0, _a = Object.keys(props); _i < _a.length; _i++) {
-            var key = _a[_i];
-            Object.defineProperty(target, key, {
-                value: props[key],
-                enumerable: false,
-                writable: false,
-                configurable: true
-            });
-        }
-        return target;
-    });
-
-    /**
-     * Returns the global object associated with provided element.
-     *
-     * @param {Object} target
-     * @returns {Object}
-     */
-    var getWindowOf = (function (target) {
-        // Assume that the element is an instance of Node, which means that it
-        // has the "ownerDocument" property from which we can retrieve a
-        // corresponding global object.
-        var ownerGlobal = target && target.ownerDocument && target.ownerDocument.defaultView;
-        // Return the local global object if it's not possible extract one from
-        // provided element.
-        return ownerGlobal || global$1;
-    });
-
-    // Placeholder of an empty content rectangle.
-    var emptyRect = createRectInit(0, 0, 0, 0);
-    /**
-     * Converts provided string to a number.
-     *
-     * @param {number|string} value
+     * @param {Array<Array>} arr
+     * @param {*} key
      * @returns {number}
      */
-    function toFloat(value) {
-        return parseFloat(value) || 0;
-    }
-    /**
-     * Extracts borders size from provided styles.
-     *
-     * @param {CSSStyleDeclaration} styles
-     * @param {...string} positions - Borders positions (top, right, ...)
-     * @returns {number}
-     */
-    function getBordersSize(styles) {
-        var positions = [];
-        for (var _i = 1; _i < arguments.length; _i++) {
-            positions[_i - 1] = arguments[_i];
-        }
-        return positions.reduce(function (size, position) {
-            var value = styles['border-' + position + '-width'];
-            return size + toFloat(value);
-        }, 0);
-    }
-    /**
-     * Extracts paddings sizes from provided styles.
-     *
-     * @param {CSSStyleDeclaration} styles
-     * @returns {Object} Paddings box.
-     */
-    function getPaddings(styles) {
-        var positions = ['top', 'right', 'bottom', 'left'];
-        var paddings = {};
-        for (var _i = 0, positions_1 = positions; _i < positions_1.length; _i++) {
-            var position = positions_1[_i];
-            var value = styles['padding-' + position];
-            paddings[position] = toFloat(value);
-        }
-        return paddings;
-    }
-    /**
-     * Calculates content rectangle of provided SVG element.
-     *
-     * @param {SVGGraphicsElement} target - Element content rectangle of which needs
-     *      to be calculated.
-     * @returns {DOMRectInit}
-     */
-    function getSVGContentRect(target) {
-        var bbox = target.getBBox();
-        return createRectInit(0, 0, bbox.width, bbox.height);
-    }
-    /**
-     * Calculates content rectangle of provided HTMLElement.
-     *
-     * @param {HTMLElement} target - Element for which to calculate the content rectangle.
-     * @returns {DOMRectInit}
-     */
-    function getHTMLElementContentRect(target) {
-        // Client width & height properties can't be
-        // used exclusively as they provide rounded values.
-        var clientWidth = target.clientWidth, clientHeight = target.clientHeight;
-        // By this condition we can catch all non-replaced inline, hidden and
-        // detached elements. Though elements with width & height properties less
-        // than 0.5 will be discarded as well.
-        //
-        // Without it we would need to implement separate methods for each of
-        // those cases and it's not possible to perform a precise and performance
-        // effective test for hidden elements. E.g. even jQuery's ':visible' filter
-        // gives wrong results for elements with width & height less than 0.5.
-        if (!clientWidth && !clientHeight) {
-            return emptyRect;
-        }
-        var styles = getWindowOf(target).getComputedStyle(target);
-        var paddings = getPaddings(styles);
-        var horizPad = paddings.left + paddings.right;
-        var vertPad = paddings.top + paddings.bottom;
-        // Computed styles of width & height are being used because they are the
-        // only dimensions available to JS that contain non-rounded values. It could
-        // be possible to utilize the getBoundingClientRect if only it's data wasn't
-        // affected by CSS transformations let alone paddings, borders and scroll bars.
-        var width = toFloat(styles.width), height = toFloat(styles.height);
-        // Width & height include paddings and borders when the 'border-box' box
-        // model is applied (except for IE).
-        if (styles.boxSizing === 'border-box') {
-            // Following conditions are required to handle Internet Explorer which
-            // doesn't include paddings and borders to computed CSS dimensions.
-            //
-            // We can say that if CSS dimensions + paddings are equal to the "client"
-            // properties then it's either IE, and thus we don't need to subtract
-            // anything, or an element merely doesn't have paddings/borders styles.
-            if (Math.round(width + horizPad) !== clientWidth) {
-                width -= getBordersSize(styles, 'left', 'right') + horizPad;
+    function getIndex(arr, key) {
+        var result = -1;
+
+        arr.some(function (entry, index) {
+            if (entry[0] === key) {
+                result = index;
+
+                return true;
             }
-            if (Math.round(height + vertPad) !== clientHeight) {
-                height -= getBordersSize(styles, 'top', 'bottom') + vertPad;
-            }
-        }
-        // Following steps can't be applied to the document's root element as its
-        // client[Width/Height] properties represent viewport area of the window.
-        // Besides, it's as well not necessary as the <html> itself neither has
-        // rendered scroll bars nor it can be clipped.
-        if (!isDocumentElement(target)) {
-            // In some browsers (only in Firefox, actually) CSS width & height
-            // include scroll bars size which can be removed at this step as scroll
-            // bars are the only difference between rounded dimensions + paddings
-            // and "client" properties, though that is not always true in Chrome.
-            var vertScrollbar = Math.round(width + horizPad) - clientWidth;
-            var horizScrollbar = Math.round(height + vertPad) - clientHeight;
-            // Chrome has a rather weird rounding of "client" properties.
-            // E.g. for an element with content width of 314.2px it sometimes gives
-            // the client width of 315px and for the width of 314.7px it may give
-            // 314px. And it doesn't happen all the time. So just ignore this delta
-            // as a non-relevant.
-            if (Math.abs(vertScrollbar) !== 1) {
-                width -= vertScrollbar;
-            }
-            if (Math.abs(horizScrollbar) !== 1) {
-                height -= horizScrollbar;
-            }
-        }
-        return createRectInit(paddings.left, paddings.top, width, height);
-    }
-    /**
-     * Checks whether provided element is an instance of the SVGGraphicsElement.
-     *
-     * @param {Element} target - Element to be checked.
-     * @returns {boolean}
-     */
-    var isSVGGraphicsElement = (function () {
-        // Some browsers, namely IE and Edge, don't have the SVGGraphicsElement
-        // interface.
-        if (typeof SVGGraphicsElement !== 'undefined') {
-            return function (target) { return target instanceof getWindowOf(target).SVGGraphicsElement; };
-        }
-        // If it's so, then check that element is at least an instance of the
-        // SVGElement and that it has the "getBBox" method.
-        // eslint-disable-next-line no-extra-parens
-        return function (target) { return (target instanceof getWindowOf(target).SVGElement &&
-            typeof target.getBBox === 'function'); };
-    })();
-    /**
-     * Checks whether provided element is a document element (<html>).
-     *
-     * @param {Element} target - Element to be checked.
-     * @returns {boolean}
-     */
-    function isDocumentElement(target) {
-        return target === getWindowOf(target).document.documentElement;
-    }
-    /**
-     * Calculates an appropriate content rectangle for provided html or svg element.
-     *
-     * @param {Element} target - Element content rectangle of which needs to be calculated.
-     * @returns {DOMRectInit}
-     */
-    function getContentRect(target) {
-        if (!isBrowser) {
-            return emptyRect;
-        }
-        if (isSVGGraphicsElement(target)) {
-            return getSVGContentRect(target);
-        }
-        return getHTMLElementContentRect(target);
-    }
-    /**
-     * Creates rectangle with an interface of the DOMRectReadOnly.
-     * Spec: https://drafts.fxtf.org/geometry/#domrectreadonly
-     *
-     * @param {DOMRectInit} rectInit - Object with rectangle's x/y coordinates and dimensions.
-     * @returns {DOMRectReadOnly}
-     */
-    function createReadOnlyRect(_a) {
-        var x = _a.x, y = _a.y, width = _a.width, height = _a.height;
-        // If DOMRectReadOnly is available use it as a prototype for the rectangle.
-        var Constr = typeof DOMRectReadOnly !== 'undefined' ? DOMRectReadOnly : Object;
-        var rect = Object.create(Constr.prototype);
-        // Rectangle's properties are not writable and non-enumerable.
-        defineConfigurable(rect, {
-            x: x, y: y, width: width, height: height,
-            top: y,
-            right: x + width,
-            bottom: height + y,
-            left: x
+
+            return false;
         });
-        return rect;
+
+        return result;
     }
+
+    return (function () {
+        function anonymous() {
+            this.__entries__ = [];
+        }
+
+        var prototypeAccessors = { size: { configurable: true } };
+
+        /**
+         * @returns {boolean}
+         */
+        prototypeAccessors.size.get = function () {
+            return this.__entries__.length;
+        };
+
+        /**
+         * @param {*} key
+         * @returns {*}
+         */
+        anonymous.prototype.get = function (key) {
+            var index = getIndex(this.__entries__, key);
+            var entry = this.__entries__[index];
+
+            return entry && entry[1];
+        };
+
+        /**
+         * @param {*} key
+         * @param {*} value
+         * @returns {void}
+         */
+        anonymous.prototype.set = function (key, value) {
+            var index = getIndex(this.__entries__, key);
+
+            if (~index) {
+                this.__entries__[index][1] = value;
+            } else {
+                this.__entries__.push([key, value]);
+            }
+        };
+
+        /**
+         * @param {*} key
+         * @returns {void}
+         */
+        anonymous.prototype.delete = function (key) {
+            var entries = this.__entries__;
+            var index = getIndex(entries, key);
+
+            if (~index) {
+                entries.splice(index, 1);
+            }
+        };
+
+        /**
+         * @param {*} key
+         * @returns {void}
+         */
+        anonymous.prototype.has = function (key) {
+            return !!~getIndex(this.__entries__, key);
+        };
+
+        /**
+         * @returns {void}
+         */
+        anonymous.prototype.clear = function () {
+            this.__entries__.splice(0);
+        };
+
+        /**
+         * @param {Function} callback
+         * @param {*} [ctx=null]
+         * @returns {void}
+         */
+        anonymous.prototype.forEach = function (callback, ctx) {
+            var this$1 = this;
+            if ( ctx === void 0 ) ctx = null;
+
+            for (var i = 0, list = this$1.__entries__; i < list.length; i += 1) {
+                var entry = list[i];
+
+                callback.call(ctx, entry[1], entry[0]);
+            }
+        };
+
+        Object.defineProperties( anonymous.prototype, prototypeAccessors );
+
+        return anonymous;
+    }());
+})();
+
+/**
+ * Detects whether window and document objects are available in current environment.
+ */
+var isBrowser = typeof window !== 'undefined' && typeof document !== 'undefined' && window.document === document;
+
+// Returns global object of a current environment.
+var global$1 = (function () {
+    if (typeof global !== 'undefined' && global.Math === Math) {
+        return global;
+    }
+
+    if (typeof self !== 'undefined' && self.Math === Math) {
+        return self;
+    }
+
+    if (typeof window !== 'undefined' && window.Math === Math) {
+        return window;
+    }
+
+    // eslint-disable-next-line no-new-func
+    return Function('return this')();
+})();
+
+/**
+ * A shim for the requestAnimationFrame which falls back to the setTimeout if
+ * first one is not supported.
+ *
+ * @returns {number} Requests' identifier.
+ */
+var requestAnimationFrame$1 = (function () {
+    if (typeof requestAnimationFrame === 'function') {
+        // It's required to use a bounded function because IE sometimes throws
+        // an "Invalid calling object" error if rAF is invoked without the global
+        // object on the left hand side.
+        return requestAnimationFrame.bind(global$1);
+    }
+
+    return function (callback) { return setTimeout(function () { return callback(Date.now()); }, 1000 / 60); };
+})();
+
+// Defines minimum timeout before adding a trailing call.
+var trailingTimeout = 2;
+
+/**
+ * Creates a wrapper function which ensures that provided callback will be
+ * invoked only once during the specified delay period.
+ *
+ * @param {Function} callback - Function to be invoked after the delay period.
+ * @param {number} delay - Delay after which to invoke callback.
+ * @returns {Function}
+ */
+var throttle = function (callback, delay) {
+    var leadingCall = false,
+        trailingCall = false,
+        lastCallTime = 0;
+
     /**
-     * Creates DOMRectInit object based on the provided dimensions and the x/y coordinates.
-     * Spec: https://drafts.fxtf.org/geometry/#dictdef-domrectinit
+     * Invokes the original callback function and schedules new invocation if
+     * the "proxy" was called during current request.
      *
-     * @param {number} x - X coordinate.
-     * @param {number} y - Y coordinate.
-     * @param {number} width - Rectangle's width.
-     * @param {number} height - Rectangle's height.
-     * @returns {DOMRectInit}
+     * @returns {void}
      */
-    function createRectInit(x, y, width, height) {
-        return { x: x, y: y, width: width, height: height };
+    function resolvePending() {
+        if (leadingCall) {
+            leadingCall = false;
+
+            callback();
+        }
+
+        if (trailingCall) {
+            proxy();
+        }
     }
 
     /**
-     * Class that is responsible for computations of the content rectangle of
-     * provided DOM element and for keeping track of it's changes.
+     * Callback invoked after the specified delay. It will further postpone
+     * invocation of the original function delegating it to the
+     * requestAnimationFrame.
+     *
+     * @returns {void}
      */
-    var ResizeObservation = /** @class */ (function () {
-        /**
-         * Creates an instance of ResizeObservation.
-         *
-         * @param {Element} target - Element to be observed.
-         */
-        function ResizeObservation(target) {
-            /**
-             * Broadcasted width of content rectangle.
-             *
-             * @type {number}
-             */
-            this.broadcastWidth = 0;
-            /**
-             * Broadcasted height of content rectangle.
-             *
-             * @type {number}
-             */
-            this.broadcastHeight = 0;
-            /**
-             * Reference to the last observed content rectangle.
-             *
-             * @private {DOMRectInit}
-             */
-            this.contentRect_ = createRectInit(0, 0, 0, 0);
-            this.target = target;
-        }
-        /**
-         * Updates content rectangle and tells whether it's width or height properties
-         * have changed since the last broadcast.
-         *
-         * @returns {boolean}
-         */
-        ResizeObservation.prototype.isActive = function () {
-            var rect = getContentRect(this.target);
-            this.contentRect_ = rect;
-            return (rect.width !== this.broadcastWidth ||
-                rect.height !== this.broadcastHeight);
-        };
-        /**
-         * Updates 'broadcastWidth' and 'broadcastHeight' properties with a data
-         * from the corresponding properties of the last observed content rectangle.
-         *
-         * @returns {DOMRectInit} Last observed content rectangle.
-         */
-        ResizeObservation.prototype.broadcastRect = function () {
-            var rect = this.contentRect_;
-            this.broadcastWidth = rect.width;
-            this.broadcastHeight = rect.height;
-            return rect;
-        };
-        return ResizeObservation;
-    }());
+    function timeoutCallback() {
+        requestAnimationFrame$1(resolvePending);
+    }
 
-    var ResizeObserverEntry = /** @class */ (function () {
-        /**
-         * Creates an instance of ResizeObserverEntry.
-         *
-         * @param {Element} target - Element that is being observed.
-         * @param {DOMRectInit} rectInit - Data of the element's content rectangle.
-         */
-        function ResizeObserverEntry(target, rectInit) {
-            var contentRect = createReadOnlyRect(rectInit);
-            // According to the specification following properties are not writable
-            // and are also not enumerable in the native implementation.
-            //
-            // Property accessors are not being used as they'd require to define a
-            // private WeakMap storage which may cause memory leaks in browsers that
-            // don't support this type of collections.
-            defineConfigurable(this, { target: target, contentRect: contentRect });
-        }
-        return ResizeObserverEntry;
-    }());
-
-    var ResizeObserverSPI = /** @class */ (function () {
-        /**
-         * Creates a new instance of ResizeObserver.
-         *
-         * @param {ResizeObserverCallback} callback - Callback function that is invoked
-         *      when one of the observed elements changes it's content dimensions.
-         * @param {ResizeObserverController} controller - Controller instance which
-         *      is responsible for the updates of observer.
-         * @param {ResizeObserver} callbackCtx - Reference to the public
-         *      ResizeObserver instance which will be passed to callback function.
-         */
-        function ResizeObserverSPI(callback, controller, callbackCtx) {
-            /**
-             * Collection of resize observations that have detected changes in dimensions
-             * of elements.
-             *
-             * @private {Array<ResizeObservation>}
-             */
-            this.activeObservations_ = [];
-            /**
-             * Registry of the ResizeObservation instances.
-             *
-             * @private {Map<Element, ResizeObservation>}
-             */
-            this.observations_ = new MapShim();
-            if (typeof callback !== 'function') {
-                throw new TypeError('The callback provided as parameter 1 is not a function.');
-            }
-            this.callback_ = callback;
-            this.controller_ = controller;
-            this.callbackCtx_ = callbackCtx;
-        }
-        /**
-         * Starts observing provided element.
-         *
-         * @param {Element} target - Element to be observed.
-         * @returns {void}
-         */
-        ResizeObserverSPI.prototype.observe = function (target) {
-            if (!arguments.length) {
-                throw new TypeError('1 argument required, but only 0 present.');
-            }
-            // Do nothing if current environment doesn't have the Element interface.
-            if (typeof Element === 'undefined' || !(Element instanceof Object)) {
-                return;
-            }
-            if (!(target instanceof getWindowOf(target).Element)) {
-                throw new TypeError('parameter 1 is not of type "Element".');
-            }
-            var observations = this.observations_;
-            // Do nothing if element is already being observed.
-            if (observations.has(target)) {
-                return;
-            }
-            observations.set(target, new ResizeObservation(target));
-            this.controller_.addObserver(this);
-            // Force the update of observations.
-            this.controller_.refresh();
-        };
-        /**
-         * Stops observing provided element.
-         *
-         * @param {Element} target - Element to stop observing.
-         * @returns {void}
-         */
-        ResizeObserverSPI.prototype.unobserve = function (target) {
-            if (!arguments.length) {
-                throw new TypeError('1 argument required, but only 0 present.');
-            }
-            // Do nothing if current environment doesn't have the Element interface.
-            if (typeof Element === 'undefined' || !(Element instanceof Object)) {
-                return;
-            }
-            if (!(target instanceof getWindowOf(target).Element)) {
-                throw new TypeError('parameter 1 is not of type "Element".');
-            }
-            var observations = this.observations_;
-            // Do nothing if element is not being observed.
-            if (!observations.has(target)) {
-                return;
-            }
-            observations.delete(target);
-            if (!observations.size) {
-                this.controller_.removeObserver(this);
-            }
-        };
-        /**
-         * Stops observing all elements.
-         *
-         * @returns {void}
-         */
-        ResizeObserverSPI.prototype.disconnect = function () {
-            this.clearActive();
-            this.observations_.clear();
-            this.controller_.removeObserver(this);
-        };
-        /**
-         * Collects observation instances the associated element of which has changed
-         * it's content rectangle.
-         *
-         * @returns {void}
-         */
-        ResizeObserverSPI.prototype.gatherActive = function () {
-            var _this = this;
-            this.clearActive();
-            this.observations_.forEach(function (observation) {
-                if (observation.isActive()) {
-                    _this.activeObservations_.push(observation);
-                }
-            });
-        };
-        /**
-         * Invokes initial callback function with a list of ResizeObserverEntry
-         * instances collected from active resize observations.
-         *
-         * @returns {void}
-         */
-        ResizeObserverSPI.prototype.broadcastActive = function () {
-            // Do nothing if observer doesn't have active observations.
-            if (!this.hasActive()) {
-                return;
-            }
-            var ctx = this.callbackCtx_;
-            // Create ResizeObserverEntry instance for every active observation.
-            var entries = this.activeObservations_.map(function (observation) {
-                return new ResizeObserverEntry(observation.target, observation.broadcastRect());
-            });
-            this.callback_.call(ctx, entries, ctx);
-            this.clearActive();
-        };
-        /**
-         * Clears the collection of active observations.
-         *
-         * @returns {void}
-         */
-        ResizeObserverSPI.prototype.clearActive = function () {
-            this.activeObservations_.splice(0);
-        };
-        /**
-         * Tells whether observer has active observations.
-         *
-         * @returns {boolean}
-         */
-        ResizeObserverSPI.prototype.hasActive = function () {
-            return this.activeObservations_.length > 0;
-        };
-        return ResizeObserverSPI;
-    }());
-
-    // Registry of internal observers. If WeakMap is not available use current shim
-    // for the Map collection as it has all required methods and because WeakMap
-    // can't be fully polyfilled anyway.
-    var observers = typeof WeakMap !== 'undefined' ? new WeakMap() : new MapShim();
     /**
-     * ResizeObserver API. Encapsulates the ResizeObserver SPI implementation
-     * exposing only those methods and properties that are defined in the spec.
+     * Schedules invocation of the original function.
+     *
+     * @returns {void}
      */
-    var ResizeObserver = /** @class */ (function () {
-        /**
-         * Creates a new instance of ResizeObserver.
-         *
-         * @param {ResizeObserverCallback} callback - Callback that is invoked when
-         *      dimensions of the observed elements change.
-         */
-        function ResizeObserver(callback) {
-            if (!(this instanceof ResizeObserver)) {
-                throw new TypeError('Cannot call a class as a function.');
+    function proxy() {
+        var timeStamp = Date.now();
+
+        if (leadingCall) {
+            // Reject immediately following calls.
+            if (timeStamp - lastCallTime < trailingTimeout) {
+                return;
             }
-            if (!arguments.length) {
-                throw new TypeError('1 argument required, but only 0 present.');
-            }
-            var controller = ResizeObserverController.getInstance();
-            var observer = new ResizeObserverSPI(callback, controller, this);
-            observers.set(this, observer);
+
+            // Schedule new call to be in invoked when the pending one is resolved.
+            // This is important for "transitions" which never actually start
+            // immediately so there is a chance that we might miss one if change
+            // happens amids the pending invocation.
+            trailingCall = true;
+        } else {
+            leadingCall = true;
+            trailingCall = false;
+
+            setTimeout(timeoutCallback, delay);
         }
-        return ResizeObserver;
-    }());
-    // Expose public methods of ResizeObserver.
-    [
-        'observe',
-        'unobserve',
-        'disconnect'
-    ].forEach(function (method) {
-        ResizeObserver.prototype[method] = function () {
-            var _a;
-            return (_a = observers.get(this))[method].apply(_a, arguments);
-        };
+
+        lastCallTime = timeStamp;
+    }
+
+    return proxy;
+};
+
+// Minimum delay before invoking the update of observers.
+var REFRESH_DELAY = 20;
+
+// A list of substrings of CSS properties used to find transition events that
+// might affect dimensions of observed elements.
+var transitionKeys = ['top', 'right', 'bottom', 'left', 'width', 'height', 'size', 'weight'];
+
+// Check if MutationObserver is available.
+var mutationObserverSupported = typeof MutationObserver !== 'undefined';
+
+/**
+ * Singleton controller class which handles updates of ResizeObserver instances.
+ */
+var ResizeObserverController = function() {
+    this.connected_ = false;
+    this.mutationEventsAdded_ = false;
+    this.mutationsObserver_ = null;
+    this.observers_ = [];
+
+    this.onTransitionEnd_ = this.onTransitionEnd_.bind(this);
+    this.refresh = throttle(this.refresh.bind(this), REFRESH_DELAY);
+};
+
+/**
+ * Adds observer to observers list.
+ *
+ * @param {ResizeObserverSPI} observer - Observer to be added.
+ * @returns {void}
+ */
+
+
+/**
+ * Holds reference to the controller's instance.
+ *
+ * @private {ResizeObserverController}
+ */
+
+
+/**
+ * Keeps reference to the instance of MutationObserver.
+ *
+ * @private {MutationObserver}
+ */
+
+/**
+ * Indicates whether DOM listeners have been added.
+ *
+ * @private {boolean}
+ */
+ResizeObserverController.prototype.addObserver = function (observer) {
+    if (!~this.observers_.indexOf(observer)) {
+        this.observers_.push(observer);
+    }
+
+    // Add listeners if they haven't been added yet.
+    if (!this.connected_) {
+        this.connect_();
+    }
+};
+
+/**
+ * Removes observer from observers list.
+ *
+ * @param {ResizeObserverSPI} observer - Observer to be removed.
+ * @returns {void}
+ */
+ResizeObserverController.prototype.removeObserver = function (observer) {
+    var observers = this.observers_;
+    var index = observers.indexOf(observer);
+
+    // Remove observer if it's present in registry.
+    if (~index) {
+        observers.splice(index, 1);
+    }
+
+    // Remove listeners if controller has no connected observers.
+    if (!observers.length && this.connected_) {
+        this.disconnect_();
+    }
+};
+
+/**
+ * Invokes the update of observers. It will continue running updates insofar
+ * it detects changes.
+ *
+ * @returns {void}
+ */
+ResizeObserverController.prototype.refresh = function () {
+    var changesDetected = this.updateObservers_();
+
+    // Continue running updates if changes have been detected as there might
+    // be future ones caused by CSS transitions.
+    if (changesDetected) {
+        this.refresh();
+    }
+};
+
+/**
+ * Updates every observer from observers list and notifies them of queued
+ * entries.
+ *
+ * @private
+ * @returns {boolean} Returns "true" if any observer has detected changes in
+ *  dimensions of it's elements.
+ */
+ResizeObserverController.prototype.updateObservers_ = function () {
+    // Collect observers that have active observations.
+    var activeObservers = this.observers_.filter(function (observer) {
+        return observer.gatherActive(), observer.hasActive();
     });
 
-    var index = (function () {
-        // Export existing implementation if available.
-        if (typeof global$1.ResizeObserver !== 'undefined') {
-            return global$1.ResizeObserver;
-        }
-        return ResizeObserver;
-    })();
+    // Deliver notifications in a separate cycle in order to avoid any
+    // collisions between observers, e.g. when multiple instances of
+    // ResizeObserver are tracking the same element and the callback of one
+    // of them changes content dimensions of the observed target. Sometimes
+    // this may result in notifications being blocked for the rest of observers.
+    activeObservers.forEach(function (observer) { return observer.broadcastActive(); });
 
-    return index;
+    return activeObservers.length > 0;
+};
+
+/**
+ * Initializes DOM listeners.
+ *
+ * @private
+ * @returns {void}
+ */
+ResizeObserverController.prototype.connect_ = function () {
+    // Do nothing if running in a non-browser environment or if listeners
+    // have been already added.
+    if (!isBrowser || this.connected_) {
+        return;
+    }
+
+    // Subscription to the "Transitionend" event is used as a workaround for
+    // delayed transitions. This way it's possible to capture at least the
+    // final state of an element.
+    document.addEventListener('transitionend', this.onTransitionEnd_);
+
+    window.addEventListener('resize', this.refresh);
+
+    if (mutationObserverSupported) {
+        this.mutationsObserver_ = new MutationObserver(this.refresh);
+
+        this.mutationsObserver_.observe(document, {
+            attributes: true,
+            childList: true,
+            characterData: true,
+            subtree: true
+        });
+    } else {
+        document.addEventListener('DOMSubtreeModified', this.refresh);
+
+        this.mutationEventsAdded_ = true;
+    }
+
+    this.connected_ = true;
+};
+
+/**
+ * Removes DOM listeners.
+ *
+ * @private
+ * @returns {void}
+ */
+ResizeObserverController.prototype.disconnect_ = function () {
+    // Do nothing if running in a non-browser environment or if listeners
+    // have been already removed.
+    if (!isBrowser || !this.connected_) {
+        return;
+    }
+
+    document.removeEventListener('transitionend', this.onTransitionEnd_);
+    window.removeEventListener('resize', this.refresh);
+
+    if (this.mutationsObserver_) {
+        this.mutationsObserver_.disconnect();
+    }
+
+    if (this.mutationEventsAdded_) {
+        document.removeEventListener('DOMSubtreeModified', this.refresh);
+    }
+
+    this.mutationsObserver_ = null;
+    this.mutationEventsAdded_ = false;
+    this.connected_ = false;
+};
+
+/**
+ * "Transitionend" event handler.
+ *
+ * @private
+ * @param {TransitionEvent} event
+ * @returns {void}
+ */
+ResizeObserverController.prototype.onTransitionEnd_ = function (ref) {
+        var propertyName = ref.propertyName; if ( propertyName === void 0 ) propertyName = '';
+
+    // Detect whether transition may affect dimensions of an element.
+    var isReflowProperty = transitionKeys.some(function (key) {
+        return !!~propertyName.indexOf(key);
+    });
+
+    if (isReflowProperty) {
+        this.refresh();
+    }
+};
+
+/**
+ * Returns instance of the ResizeObserverController.
+ *
+ * @returns {ResizeObserverController}
+ */
+ResizeObserverController.getInstance = function () {
+    if (!this.instance_) {
+        this.instance_ = new ResizeObserverController();
+    }
+
+    return this.instance_;
+};
+
+ResizeObserverController.instance_ = null;
+
+/**
+ * Defines non-writable/enumerable properties of the provided target object.
+ *
+ * @param {Object} target - Object for which to define properties.
+ * @param {Object} props - Properties to be defined.
+ * @returns {Object} Target object.
+ */
+var defineConfigurable = (function (target, props) {
+    for (var i = 0, list = Object.keys(props); i < list.length; i += 1) {
+        var key = list[i];
+
+        Object.defineProperty(target, key, {
+            value: props[key],
+            enumerable: false,
+            writable: false,
+            configurable: true
+        });
+    }
+
+    return target;
+});
+
+/**
+ * Returns the global object associated with provided element.
+ *
+ * @param {Object} target
+ * @returns {Object}
+ */
+var getWindowOf = (function (target) {
+    // Assume that the element is an instance of Node, which means that it
+    // has the "ownerDocument" property from which we can retrieve a
+    // corresponding global object.
+    var ownerGlobal = target && target.ownerDocument && target.ownerDocument.defaultView;
+
+    // Return the local global object if it's not possible extract one from
+    // provided element.
+    return ownerGlobal || global$1;
+});
+
+// Placeholder of an empty content rectangle.
+var emptyRect = createRectInit(0, 0, 0, 0);
+
+/**
+ * Converts provided string to a number.
+ *
+ * @param {number|string} value
+ * @returns {number}
+ */
+function toFloat(value) {
+    return parseFloat(value) || 0;
+}
+
+/**
+ * Extracts borders size from provided styles.
+ *
+ * @param {CSSStyleDeclaration} styles
+ * @param {...string} positions - Borders positions (top, right, ...)
+ * @returns {number}
+ */
+function getBordersSize(styles) {
+    var positions = [], len = arguments.length - 1;
+    while ( len-- > 0 ) positions[ len ] = arguments[ len + 1 ];
+
+    return positions.reduce(function (size, position) {
+        var value = styles['border-' + position + '-width'];
+
+        return size + toFloat(value);
+    }, 0);
+}
+
+/**
+ * Extracts paddings sizes from provided styles.
+ *
+ * @param {CSSStyleDeclaration} styles
+ * @returns {Object} Paddings box.
+ */
+function getPaddings(styles) {
+    var positions = ['top', 'right', 'bottom', 'left'];
+    var paddings = {};
+
+    for (var i = 0, list = positions; i < list.length; i += 1) {
+        var position = list[i];
+
+        var value = styles['padding-' + position];
+
+        paddings[position] = toFloat(value);
+    }
+
+    return paddings;
+}
+
+/**
+ * Calculates content rectangle of provided SVG element.
+ *
+ * @param {SVGGraphicsElement} target - Element content rectangle of which needs
+ *      to be calculated.
+ * @returns {DOMRectInit}
+ */
+function getSVGContentRect(target) {
+    var bbox = target.getBBox();
+
+    return createRectInit(0, 0, bbox.width, bbox.height);
+}
+
+/**
+ * Calculates content rectangle of provided HTMLElement.
+ *
+ * @param {HTMLElement} target - Element for which to calculate the content rectangle.
+ * @returns {DOMRectInit}
+ */
+function getHTMLElementContentRect(target) {
+    // Client width & height properties can't be
+    // used exclusively as they provide rounded values.
+    var clientWidth = target.clientWidth;
+    var clientHeight = target.clientHeight;
+
+    // By this condition we can catch all non-replaced inline, hidden and
+    // detached elements. Though elements with width & height properties less
+    // than 0.5 will be discarded as well.
+    //
+    // Without it we would need to implement separate methods for each of
+    // those cases and it's not possible to perform a precise and performance
+    // effective test for hidden elements. E.g. even jQuery's ':visible' filter
+    // gives wrong results for elements with width & height less than 0.5.
+    if (!clientWidth && !clientHeight) {
+        return emptyRect;
+    }
+
+    var styles = getWindowOf(target).getComputedStyle(target);
+    var paddings = getPaddings(styles);
+    var horizPad = paddings.left + paddings.right;
+    var vertPad = paddings.top + paddings.bottom;
+
+    // Computed styles of width & height are being used because they are the
+    // only dimensions available to JS that contain non-rounded values. It could
+    // be possible to utilize the getBoundingClientRect if only it's data wasn't
+    // affected by CSS transformations let alone paddings, borders and scroll bars.
+    var width = toFloat(styles.width),
+        height = toFloat(styles.height);
+
+    // Width & height include paddings and borders when the 'border-box' box
+    // model is applied (except for IE).
+    if (styles.boxSizing === 'border-box') {
+        // Following conditions are required to handle Internet Explorer which
+        // doesn't include paddings and borders to computed CSS dimensions.
+        //
+        // We can say that if CSS dimensions + paddings are equal to the "client"
+        // properties then it's either IE, and thus we don't need to subtract
+        // anything, or an element merely doesn't have paddings/borders styles.
+        if (Math.round(width + horizPad) !== clientWidth) {
+            width -= getBordersSize(styles, 'left', 'right') + horizPad;
+        }
+
+        if (Math.round(height + vertPad) !== clientHeight) {
+            height -= getBordersSize(styles, 'top', 'bottom') + vertPad;
+        }
+    }
+
+    // Following steps can't be applied to the document's root element as its
+    // client[Width/Height] properties represent viewport area of the window.
+    // Besides, it's as well not necessary as the <html> itself neither has
+    // rendered scroll bars nor it can be clipped.
+    if (!isDocumentElement(target)) {
+        // In some browsers (only in Firefox, actually) CSS width & height
+        // include scroll bars size which can be removed at this step as scroll
+        // bars are the only difference between rounded dimensions + paddings
+        // and "client" properties, though that is not always true in Chrome.
+        var vertScrollbar = Math.round(width + horizPad) - clientWidth;
+        var horizScrollbar = Math.round(height + vertPad) - clientHeight;
+
+        // Chrome has a rather weird rounding of "client" properties.
+        // E.g. for an element with content width of 314.2px it sometimes gives
+        // the client width of 315px and for the width of 314.7px it may give
+        // 314px. And it doesn't happen all the time. So just ignore this delta
+        // as a non-relevant.
+        if (Math.abs(vertScrollbar) !== 1) {
+            width -= vertScrollbar;
+        }
+
+        if (Math.abs(horizScrollbar) !== 1) {
+            height -= horizScrollbar;
+        }
+    }
+
+    return createRectInit(paddings.left, paddings.top, width, height);
+}
+
+/**
+ * Checks whether provided element is an instance of the SVGGraphicsElement.
+ *
+ * @param {Element} target - Element to be checked.
+ * @returns {boolean}
+ */
+var isSVGGraphicsElement = (function () {
+    // Some browsers, namely IE and Edge, don't have the SVGGraphicsElement
+    // interface.
+    if (typeof SVGGraphicsElement !== 'undefined') {
+        return function (target) { return target instanceof getWindowOf(target).SVGGraphicsElement; };
+    }
+
+    // If it's so, then check that element is at least an instance of the
+    // SVGElement and that it has the "getBBox" method.
+    // eslint-disable-next-line no-extra-parens
+    return function (target) { return target instanceof getWindowOf(target).SVGElement && typeof target.getBBox === 'function'; };
+})();
+
+/**
+ * Checks whether provided element is a document element (<html>).
+ *
+ * @param {Element} target - Element to be checked.
+ * @returns {boolean}
+ */
+function isDocumentElement(target) {
+    return target === getWindowOf(target).document.documentElement;
+}
+
+/**
+ * Calculates an appropriate content rectangle for provided html or svg element.
+ *
+ * @param {Element} target - Element content rectangle of which needs to be calculated.
+ * @returns {DOMRectInit}
+ */
+function getContentRect(target) {
+    if (!isBrowser) {
+        return emptyRect;
+    }
+
+    if (isSVGGraphicsElement(target)) {
+        return getSVGContentRect(target);
+    }
+
+    return getHTMLElementContentRect(target);
+}
+
+/**
+ * Creates rectangle with an interface of the DOMRectReadOnly.
+ * Spec: https://drafts.fxtf.org/geometry/#domrectreadonly
+ *
+ * @param {DOMRectInit} rectInit - Object with rectangle's x/y coordinates and dimensions.
+ * @returns {DOMRectReadOnly}
+ */
+function createReadOnlyRect(ref) {
+    var x = ref.x;
+    var y = ref.y;
+    var width = ref.width;
+    var height = ref.height;
+
+    // If DOMRectReadOnly is available use it as a prototype for the rectangle.
+    var Constr = typeof DOMRectReadOnly !== 'undefined' ? DOMRectReadOnly : Object;
+    var rect = Object.create(Constr.prototype);
+
+    // Rectangle's properties are not writable and non-enumerable.
+    defineConfigurable(rect, {
+        x: x, y: y, width: width, height: height,
+        top: y,
+        right: x + width,
+        bottom: height + y,
+        left: x
+    });
+
+    return rect;
+}
+
+/**
+ * Creates DOMRectInit object based on the provided dimensions and the x/y coordinates.
+ * Spec: https://drafts.fxtf.org/geometry/#dictdef-domrectinit
+ *
+ * @param {number} x - X coordinate.
+ * @param {number} y - Y coordinate.
+ * @param {number} width - Rectangle's width.
+ * @param {number} height - Rectangle's height.
+ * @returns {DOMRectInit}
+ */
+function createRectInit(x, y, width, height) {
+    return { x: x, y: y, width: width, height: height };
+}
+
+/**
+ * Class that is responsible for computations of the content rectangle of
+ * provided DOM element and for keeping track of it's changes.
+ */
+var ResizeObservation = function(target) {
+    this.broadcastWidth = 0;
+    this.broadcastHeight = 0;
+    this.contentRect_ = createRectInit(0, 0, 0, 0);
+
+    this.target = target;
+};
+
+/**
+ * Updates content rectangle and tells whether it's width or height properties
+ * have changed since the last broadcast.
+ *
+ * @returns {boolean}
+ */
+
+
+/**
+ * Reference to the last observed content rectangle.
+ *
+ * @private {DOMRectInit}
+ */
+
+
+/**
+ * Broadcasted width of content rectangle.
+ *
+ * @type {number}
+ */
+ResizeObservation.prototype.isActive = function () {
+    var rect = getContentRect(this.target);
+
+    this.contentRect_ = rect;
+
+    return rect.width !== this.broadcastWidth || rect.height !== this.broadcastHeight;
+};
+
+/**
+ * Updates 'broadcastWidth' and 'broadcastHeight' properties with a data
+ * from the corresponding properties of the last observed content rectangle.
+ *
+ * @returns {DOMRectInit} Last observed content rectangle.
+ */
+ResizeObservation.prototype.broadcastRect = function () {
+    var rect = this.contentRect_;
+
+    this.broadcastWidth = rect.width;
+    this.broadcastHeight = rect.height;
+
+    return rect;
+};
+
+var ResizeObserverEntry = function(target, rectInit) {
+    var contentRect = createReadOnlyRect(rectInit);
+
+    // According to the specification following properties are not writable
+    // and are also not enumerable in the native implementation.
+    //
+    // Property accessors are not being used as they'd require to define a
+    // private WeakMap storage which may cause memory leaks in browsers that
+    // don't support this type of collections.
+    defineConfigurable(this, { target: target, contentRect: contentRect });
+};
+
+var ResizeObserverSPI = function(callback, controller, callbackCtx) {
+    this.activeObservations_ = [];
+    this.observations_ = new MapShim();
+
+    if (typeof callback !== 'function') {
+        throw new TypeError('The callback provided as parameter 1 is not a function.');
+    }
+
+    this.callback_ = callback;
+    this.controller_ = controller;
+    this.callbackCtx_ = callbackCtx;
+};
+
+/**
+ * Starts observing provided element.
+ *
+ * @param {Element} target - Element to be observed.
+ * @returns {void}
+ */
+
+
+/**
+ * Registry of the ResizeObservation instances.
+ *
+ * @private {Map<Element, ResizeObservation>}
+ */
+
+
+/**
+ * Public ResizeObserver instance which will be passed to the callback
+ * function and used as a value of it's "this" binding.
+ *
+ * @private {ResizeObserver}
+ */
+
+/**
+ * Collection of resize observations that have detected changes in dimensions
+ * of elements.
+ *
+ * @private {Array<ResizeObservation>}
+ */
+ResizeObserverSPI.prototype.observe = function (target) {
+    if (!arguments.length) {
+        throw new TypeError('1 argument required, but only 0 present.');
+    }
+
+    // Do nothing if current environment doesn't have the Element interface.
+    if (typeof Element === 'undefined' || !(Element instanceof Object)) {
+        return;
+    }
+
+    if (!(target instanceof getWindowOf(target).Element)) {
+        throw new TypeError('parameter 1 is not of type "Element".');
+    }
+
+    var observations = this.observations_;
+
+    // Do nothing if element is already being observed.
+    if (observations.has(target)) {
+        return;
+    }
+
+    observations.set(target, new ResizeObservation(target));
+
+    this.controller_.addObserver(this);
+
+    // Force the update of observations.
+    this.controller_.refresh();
+};
+
+/**
+ * Stops observing provided element.
+ *
+ * @param {Element} target - Element to stop observing.
+ * @returns {void}
+ */
+ResizeObserverSPI.prototype.unobserve = function (target) {
+    if (!arguments.length) {
+        throw new TypeError('1 argument required, but only 0 present.');
+    }
+
+    // Do nothing if current environment doesn't have the Element interface.
+    if (typeof Element === 'undefined' || !(Element instanceof Object)) {
+        return;
+    }
+
+    if (!(target instanceof getWindowOf(target).Element)) {
+        throw new TypeError('parameter 1 is not of type "Element".');
+    }
+
+    var observations = this.observations_;
+
+    // Do nothing if element is not being observed.
+    if (!observations.has(target)) {
+        return;
+    }
+
+    observations.delete(target);
+
+    if (!observations.size) {
+        this.controller_.removeObserver(this);
+    }
+};
+
+/**
+ * Stops observing all elements.
+ *
+ * @returns {void}
+ */
+ResizeObserverSPI.prototype.disconnect = function () {
+    this.clearActive();
+    this.observations_.clear();
+    this.controller_.removeObserver(this);
+};
+
+/**
+ * Collects observation instances the associated element of which has changed
+ * it's content rectangle.
+ *
+ * @returns {void}
+ */
+ResizeObserverSPI.prototype.gatherActive = function () {
+        var this$1 = this;
+
+    this.clearActive();
+
+    this.observations_.forEach(function (observation) {
+        if (observation.isActive()) {
+            this$1.activeObservations_.push(observation);
+        }
+    });
+};
+
+/**
+ * Invokes initial callback function with a list of ResizeObserverEntry
+ * instances collected from active resize observations.
+ *
+ * @returns {void}
+ */
+ResizeObserverSPI.prototype.broadcastActive = function () {
+    // Do nothing if observer doesn't have active observations.
+    if (!this.hasActive()) {
+        return;
+    }
+
+    var ctx = this.callbackCtx_;
+
+    // Create ResizeObserverEntry instance for every active observation.
+    var entries = this.activeObservations_.map(function (observation) {
+        return new ResizeObserverEntry(observation.target, observation.broadcastRect());
+    });
+
+    this.callback_.call(ctx, entries, ctx);
+    this.clearActive();
+};
+
+/**
+ * Clears the collection of active observations.
+ *
+ * @returns {void}
+ */
+ResizeObserverSPI.prototype.clearActive = function () {
+    this.activeObservations_.splice(0);
+};
+
+/**
+ * Tells whether observer has active observations.
+ *
+ * @returns {boolean}
+ */
+ResizeObserverSPI.prototype.hasActive = function () {
+    return this.activeObservations_.length > 0;
+};
+
+// Registry of internal observers. If WeakMap is not available use current shim
+// for the Map collection as it has all required methods and because WeakMap
+// can't be fully polyfilled anyway.
+var observers = typeof WeakMap !== 'undefined' ? new WeakMap() : new MapShim();
+
+/**
+ * ResizeObserver API. Encapsulates the ResizeObserver SPI implementation
+ * exposing only those methods and properties that are defined in the spec.
+ */
+var ResizeObserver = function(callback) {
+    if (!(this instanceof ResizeObserver)) {
+        throw new TypeError('Cannot call a class as a function.');
+    }
+    if (!arguments.length) {
+        throw new TypeError('1 argument required, but only 0 present.');
+    }
+
+    var controller = ResizeObserverController.getInstance();
+    var observer = new ResizeObserverSPI(callback, controller, this);
+
+    observers.set(this, observer);
+};
+
+// Expose public methods of ResizeObserver.
+['observe', 'unobserve', 'disconnect'].forEach(function (method) {
+    ResizeObserver.prototype[method] = function () {
+        return (ref = observers.get(this))[method].apply(ref, arguments);
+        var ref;
+    };
+});
+
+var index = (function () {
+    // Export existing implementation if available.
+    if (typeof global$1.ResizeObserver !== 'undefined') {
+        return global$1.ResizeObserver;
+    }
+
+    global$1.ResizeObserver = ResizeObserver;
+
+    return ResizeObserver;
+})();
+
+return index;
 
 })));

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "Pattern library for ONS website",
     "main": "",
     "config": {
-        "js": "js/thirdparty/jquery.js js/thirdparty/details.polyfill.js js/thirdparty/doubletaptogo.js js/app.js js/app/cookies-banner.js js/app/cookies-pref.js js/app/display.js  js/app/preview.js js/app/checkboxes.js js/app/viewport-size.js js/app/gtm.js js/app/nav.js js/app/show-and-hide.js js/app/show-more-list.js js/app/sticky-scroll.js js/app/date-picker.js js/app/table-of-contents.js js/app/mobile-filters.js js/app/equal-height.js js/app/print-page.js js/app/hover-state.js js/app/scroll.js js/app/loading-screen.js js/app/date-range-updater.js js/app/filter-options.js js/app/time-selector.js js/app/filter-select.js js/app/improve-this-page.js js/app/embed-code-copy.js js/app/tile.js"
+        "js": "js/thirdparty/jquery.js js/thirdparty/details.polyfill.js js/thirdparty/doubletaptogo.js js/thirdparty/resize-observer-polyfill.js js/app.js js/app/cookies-banner.js js/app/cookies-pref.js js/app/display.js  js/app/preview.js js/app/checkboxes.js js/app/viewport-size.js js/app/gtm.js js/app/nav.js js/app/show-and-hide.js js/app/show-more-list.js js/app/sticky-scroll.js js/app/date-picker.js js/app/table-of-contents.js js/app/mobile-filters.js js/app/equal-height.js js/app/print-page.js js/app/hover-state.js js/app/scroll.js js/app/loading-screen.js js/app/date-range-updater.js js/app/filter-options.js js/app/time-selector.js js/app/filter-select.js js/app/improve-this-page.js js/app/embed-code-copy.js js/app/tile.js js/app/scrollable-container.js"
     },
     "scripts": {
         "clean": "",

--- a/scss/components/_scrollable-container.scss
+++ b/scss/components/_scrollable-container.scss
@@ -26,6 +26,6 @@
 
     &:after {
         right: 0;
-        box-shadow: inset 1px 0 0 0 #bfc1c3,inset -5px 0 0 0 rgba(191,193,195,.4);
+        box-shadow: inset -1px 0 0 0 #bfc1c3,inset -5px 0 0 0 rgba(191,193,195,.4);
     }
 }

--- a/scss/components/_scrollable-container.scss
+++ b/scss/components/_scrollable-container.scss
@@ -5,7 +5,11 @@
 .scrollable-container {
     overflow: visible;
     overflow-x: scroll;
-    width: 100%;
+    width: $col * 45;
+
+    @include breakpoint(md-max) {
+        width: 100%;
+    }
 }
 
 .scrollable-container__overflow{

--- a/scss/components/_scrollable-container.scss
+++ b/scss/components/_scrollable-container.scss
@@ -17,6 +17,7 @@
         position: absolute;
         z-index: 200;
         top: 0;
+        display: none;
     }
 
     &:before {
@@ -24,8 +25,16 @@
         box-shadow: inset 1px 0 0 0 #bfc1c3,inset -5px 0 0 0 rgba(191,193,195,.4)
     }
 
+    &.scroll-container__left-shadow:before {
+        display: block;
+    }
+
     &:after {
         right: 0;
         box-shadow: inset -1px 0 0 0 #bfc1c3,inset -5px 0 0 0 rgba(191,193,195,.4);
+    }
+
+    &.scroll-container__right-shadow:after {
+        display: block;
     }
 }

--- a/scss/components/_scrollable-container.scss
+++ b/scss/components/_scrollable-container.scss
@@ -1,0 +1,31 @@
+.scrollable-container__parent {
+    position: relative;
+}
+
+.scrollable-container {
+    overflow: visible;
+    overflow-x: scroll;
+    width: 100%;
+}
+
+.scrollable-container__overflow{
+    &:after, &:before {
+        content: '';
+        height: 100%;
+        width: 5px;
+        display: block;
+        position: absolute;
+        z-index: 200;
+        top: 0;
+    }
+
+    &:before {
+        left: 0;
+        box-shadow: inset 1px 0 0 0 #bfc1c3,inset -5px 0 0 0 rgba(191,193,195,.4)
+    }
+
+    &:after {
+        right: 0;
+        box-shadow: inset 1px 0 0 0 #bfc1c3,inset -5px 0 0 0 rgba(191,193,195,.4);
+    }
+}

--- a/scss/components/_scrollable-container.scss
+++ b/scss/components/_scrollable-container.scss
@@ -19,7 +19,7 @@
         width: 5px;
         display: block;
         position: absolute;
-        z-index: 200;
+        z-index: 5;
         top: 0;
         display: none;
     }

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -77,6 +77,7 @@ $old-ie: false;
 @import "components/improve-this-page";
 @import "components/form";
 @import "components/embed-code";
+@import "components/scrollable-container";
 
 @import "v2/components/promo";
 


### PR DESCRIPTION
### What
Use scrollable overflows with shadows for charts so that the users aren't forced to scroll horizontally on small and medium viewports.

### How to review
1. Visit an article or bulletin with a chart
1. At small and medium viewport sizes see that they need to scroll horizontally
1. Switch to this branch and checkout babbage branch `fix/overflow-shadows`
1. See that there is now a scroll bar and shadows that appear showing that there is more content.

### Who can review
Anyone but me