### PR TITLE
Fix - Remove fixed width causing overflow issue for reflow

### DIFF
--- a/js/app/preview.js
+++ b/js/app/preview.js
@@ -83,7 +83,7 @@ function addFilesToPage(files) {
     var csvURL = files.downloads.csv.href,
         csvFileSize = files.downloads.csv.size,
         csvFile = $('<li class="padding-left--1 margin-top--0 margin-bottom--1 white-background clearfix">' +
-                    '<span class="inline-block width--24 padding-top--2">Filtered dataset (<span class="uppercase">csv</span> format)</span>' +
+                    '<span class="inline-block padding-top--2">Filtered dataset (<span class="uppercase">csv</span> format)</span>' +
                     '<div class="width--12 inline-block float-right text-right">' +
                     '<a id="csv-download" class="btn btn--primary margin-top--1 margin-bottom--1 margin-right--half width--11" href="' + csvURL + '" aria-label="Download the filtered dataset as csv (' + formatBytes(csvFileSize) + ')"><span role="text"><strong>csv</strong> ('+ formatBytes(csvFileSize) +')</span></a></div></li>');
 


### PR DESCRIPTION
### What
Fix CMD download options text overflow by removing text fixed width which does not work at such a small viewport width.

### How to review
1. Visit a CMD dataset page and CMD filtered results page
1. Expand the "Other download options" set the viewport width to 320px
1. See that some of the options overflow
1. Switch to this branch and dp-frontend-renderer branch `fix/reflow-cmd-download`
1. See that the issues is fixed.

### Who can review
Anyone but me
