### PR TITLE
Fix - mobile nav language overflow

### DIFF
--- a/scss/components/_header.scss
+++ b/scss/components/_header.scss
@@ -202,43 +202,12 @@
         }
     }
 
-    // SECONDARY NAV CONTENT - ONLY SHOW ON MOBILE
-
-    //&--secondary {
-    //
-    //
-    //	&__list {
-    //
-    //		@include breakpoint(sm) {
-    //			padding: 0 0 $baseline 0;
-    //			margin: 0;
-    //		}
-    //
-    //		@include breakpoint(md) {
-    //			display: none;
-    //		}
-    //	}
-    //
-    //	&__item {
-    //
-    //		@include breakpoint(sm) {
-    //			display: block;
-    //			padding: 0;
-    //			margin: 0;
-    //			height: $baseline * 6;
-    //			cursor: pointer;
-    //		}
-    //	}
-    //
-    //	&__link {
-    //		@include breakpoint(sm) {
-    //			display: block;
-    //			height: $baseline * 6;
-    //			padding: 14px 0 10px $col;
-    //			color: $iron-light;
-    //		}
-    //	}
-    //}
+    &__language {
+        display: block;
+        color: $iron-light;
+        overflow: hidden;
+        margin: 0;
+    }
 }
 
 //JQUERY EXPANDABLE MOBILE MENU - temporary until we write our own JS in new library


### PR DESCRIPTION
### What
When expanding a collapsed menu item in the mobile menu then the language option overflows the menu and ends with nearly white text on white background.

### How to review
1. Visit any page (a babbage or renderer)
1. Expand the menu
1. Expand a collapsed menu item
1. See that language link (at the bottom) has overflowed the menu
1. Switch to branches
    1. Sixteens - `fix/mobile-nav-lang-overflow`
    1. dp-frontend-render- `fix/mobile-nav-lang-overflow`
    1. babbage - `fix/mobile-nav-lang-overflow`
1. See that it is resolved

### Who can review
Anyone but me
