### PR TITLE
Fix/download status2

### DIFF
--- a/js/app/preview.js
+++ b/js/app/preview.js
@@ -12,8 +12,8 @@ if ($('#preview-and-download').length) {
 var loader = $('.loader-svg'),
     message = $('<h3 class="margin-bottom" role="alert">There has been an error creating your files. Try refreshing the page.</h3>' +
                 '<a class="btn btn--primary btn--thick margin-bottom--4 btn--focus font-size--19" href="' + window.location.pathname + '">Refresh page</a>'),
-    preparingAlert = $('<div aria-label="Preparing your download" role="alert"></div>'),
-    downloadReady = $('<div role="alert" aria-label="The download is ready"></div>'),
+    preparingAlert = $('<p role="alert" class="visuallyhidden">Preparing your download</p>'),
+    downloadReady = $('<p role="alert" class="visuallyhidden">The download is ready</p>'),
     count = 0;
 
 function fileHasLoaded(downloads) {

--- a/js/app/preview.js
+++ b/js/app/preview.js
@@ -64,7 +64,7 @@ function getDownloadFiles() {
             count++;
             loader.removeClass('js-hidden');
             $('#excel-file').attr('aria-hidden', true);
-            if (count === 1) {
+            if (count === 2) {
                 preparingAlert.prependTo(loader);
             }
             setTimeout(function() { getDownloadFiles(); }, 2000);


### PR DESCRIPTION
### What

Updates to the download status alerts to make them work across all screenreader platforms

### How to review

(Focus on iPhone as this is where the first version was not working correctly)

- Use a screen reader
- Apply filters to a dataset to create a custom download.
- When you landing on the download preview page the screen reader should announce that either:
  - 'The download is ready', if the download button is available
  - or 'Preparing your download', if the spinner is visible.
- If the spinner is initially visible, then once it disappears the screen reader should announce that either:
  - 'The download is ready', if the download button is now available
  - or 'There has been an error creating your files. Try refreshing the page.', if an error has occurred.

### Who can review

Anyone but me
