### PR TITLE
Fix - Invalid break tag in dl

### DIFF
--- a/scss/components/_tiles.scss
+++ b/scss/components/_tiles.scss
@@ -818,9 +818,14 @@
 			margin: 0;
 			padding: 6px 0 2px 0;
 		}
-		dd,
-		dt {
-			display: inline-block;
+
+		dt, dd {
+			display: inline;
+		}
+
+		dt:not(:first-of-type):before {
+			content: '\A';
+			white-space: pre;
 		}
 
 		.stand-out {


### PR DESCRIPTION
### What
Remove break tag from dl and use CSS instead to style the items
Tested in IE11 which supports `:not(:first-of-type)`!

### How to review
1. Visit a page with a `product_page` with a break tag in a `dl` e.g. https://www.ons.gov.uk/employmentandlabourmarket/peopleinwork/earningsandworkinghours
1. See the layout
1. Switch to this branch and babbage branch `fix/invalid-br-in-dl`
1. See that the break tag is gone and the layout is unaffected

### Who can review
Anyone but me
