### PR TITLE
Restyle meta when using ul instead of dl

### DIFF
--- a/scss/components/_meta.scss
+++ b/scss/components/_meta.scss
@@ -33,7 +33,6 @@
 	}
 
 	&__item {
-		// border-right: 1px solid $iron;
 		padding-left: $col;
 		margin-top: 0;
 		margin-bottom: ($baseline * 3);
@@ -58,6 +57,17 @@
 		height: 47px;
 		float: left;
 		margin-right: 16px;
+	}
+
+	&__list {
+		list-style: none;
+		margin-top: 0;
+		margin-bottom: 0;
+		padding-left: 0;
+
+		.meta__item {
+			padding: 0 0 0 $col;
+		}
 	}
 
 }


### PR DESCRIPTION
### What
Fix issue on dataset landing page with invalid anchor within a `dl`.

Tried wrapping anchor in div but didn't work 😭 

Change has no noticeable affect to screen readers.

### How to review
1. Load a dataset landing page
1. See there are invalid (non `dt`, `dd` or `div`. Not `a`) elements children of a `dl` (AXE)
1. Switch to this branch and dp-frontend-renderer brach `fix/invalid-dl`
1. See this has been switched to a `ul`, `li` and `div`.

### Who can review
Anyone but me
