### PR TITLE
Fix - CMD filters duplicate ids

### DIFF
--- a/js/app/filter-select.js
+++ b/js/app/filter-select.js
@@ -81,7 +81,7 @@ $(function() {
       filterSelectItem =
           '<li><span class="col col--md-6 col--lg-12">' + label +
           '</span><span class="remove-link js-filter">' +
-          '<a href="' + url + '/remove/' + id + '" id="' + id + '">Remove</a></li>';
+          '<a href="' + url + '/remove/' + id + '" data-id="'+ id +'">Remove</a></li>';
       // Build remove all link
       removeAllLink =
           '<a class="remove-all js-filter" href="' + urlToPost +
@@ -100,12 +100,12 @@ $(function() {
   function removeFilter(el){
     // Case - if checkbox is clicked
     if(el.is(checkBox)){
-      filterSelectList.find('a#'+id).parents('li').remove();
+      filterSelectList.find('a[data-id="' + id + '"]').parents('li').remove();
       el.removeClass('checked');
 
     // Case - if single remove linked clicked
     } else if (el.is(removeOne)) {
-      id = el.find('a').attr('id');
+      id = el.find('a').attr('data-id');
       el.parents('li').remove();
       urlToPost = url + '/remove/' + id;
       $('.checkbox__input[name="'+id+'"]').prop('checked', false)
@@ -123,7 +123,7 @@ $(function() {
       checkBox.each(function(){
         id = $(this).attr('name');
         filterSelectList.children('li').each(function(){
-          $(this).find('a#'+id).parents('li').remove();
+          $(this).find('a[data-id="' + id + '"]').parents('li').remove();
         });
       });
     }


### PR DESCRIPTION
### What
When adding a filter to the selected filters in CMD hierarchy and geography pages then the ids would be duplicated between input and the remove link.

### How to review
1. Load a CMD hierarchy or geography page
1. Select a filter
1. See that the ids are duplicated
1. Switch to this branch and dp-frontend-renderer `fix/duplicate-ids-cmd-filters`
1. See that there are no ids when added by JS or on refresh

### Who can review
Anyone but me
