### PR TITLE
Fix - Duplicate ids from viewport sizes

### DIFF
--- a/js/app/viewport-size.js
+++ b/js/app/viewport-size.js
@@ -1,5 +1,10 @@
 $(function() {
-    $("footer").append("<div id='viewport-sm' class='js-viewport-size'></div>" +
+    var footers = $('footer');
+    if (footers.length == 0) {
+        return;
+    }
+    // Get the last one expected to be the main one for the page
+    $(footers.get(footers.length - 1)).append("<div id='viewport-sm' class='js-viewport-size'></div>" +
         "<div id='viewport-md' class='js-viewport-size'></div>" +
         "<div id='viewport-lg' class='js-viewport-size'></div>");
 


### PR DESCRIPTION
### What
When you have a v2 table with footnotes then you end up with multiple `footer` elements on the page.
Given the previous implementation this resulted in duplicate ids (e.g. `viewport-sm` etc) one for each `footer`.

This change ensures that we only use the main page footer to hold the viewport size elements.

### How to review
1. Load an article page with a v2 table with footnotes
1. See there are duplicate ids of the viewport elements
1. Switch this branch
1. See that this is resolved

### Who can review
Anyone but me
