### PR TITLE
Fix - Duplicate ids - CMD filters overview page

### DIFF
--- a/js/app/filter-options.js
+++ b/js/app/filter-options.js
@@ -7,12 +7,12 @@ $(document).ready(function() {
             return
         }
 
-        $("li#filter-option").each(function() {
+        $(".js-filter-option").each(function() {
             if ($(this).hasClass("filter-overview__add")) {
                 e.preventDefault();
                 $(this).removeClass("filter-overview__add");
                 $(this).addClass("filter-overview__error");
-                var label = $(this).find("#filter-option-label").html();
+                var label = $(this).find(".js-filter-option-label").html();
                 if (errorDimensions.length > 0) {
                     label = " " + label;
                 }
@@ -32,17 +32,17 @@ $(document).ready(function() {
         }
     })
 
-    $("li#filter-option").hover(function() {
-        var label = $(this).find("#filter-option-label");
+    $(".js-filter-option").hover(function() {
+        var label = $(this).find(".js-filter-option-label");
         var labelText = label.text();
         var url = $(this).find("a").attr("href");
-        var newLabel = "<a id=\"filter-option-label\" class=\"font-size-16\" href=\""+url+"\">"+labelText+"</a>"
+        var newLabel = "<a class=\"js-filter-option-label font-size-16\" href=\""+url+"\">"+labelText+"</a>"
 
         label.replaceWith(newLabel);
     }, function() {
-        var label = $(this).find("#filter-option-label");
+        var label = $(this).find(".js-filter-option-label");
         var labelText = label.text();
-        var newLabel = "<span id=\"filter-option-label\" class=\"font-size-16\">"+labelText+"</a>"
+        var newLabel = "<span class=\"js-filter-option-label font-size-16\">"+labelText+"</a>"
 
         label.replaceWith(newLabel);
     });


### PR DESCRIPTION
### What
Use classes instead of ids as there are multiple filter options on the filters overview page

### How to review
1. Visit the filter overview page for a dataset with multiple filters
1. See that the ids for the list item and text content are duplicated
1. Switch to this branch and dp-frontend-renderer branch `fix/duplicate-ids-cmd-filter-options`
1. See that this issue is now resolved and exiting click and hover functionality is maintained

### Who can review
Anyone but me
