### PR TITLE
Fix -  Remove invalid aria attribute

### DIFF
--- a/js/app/checkboxes.js
+++ b/js/app/checkboxes.js
@@ -39,11 +39,6 @@ $(function() {
     		var relatedSelector = $(this).prev(),
     			selectAll = relatedSelector.find('#select-all'),
     			selectNone = relatedSelector.find('#select-none');
-
-            // create unique id for aria relationship and add to the button wrapper and each checkbox group.
-            var ariaId = 'checkboxes-' + i;
-            $(this).attr('id', ariaId);
-            $(relatedSelector).attr('aria-contols', ariaId);
     		
     		// When all checkboxes are checked.
 	    	if ($('input:checked', this).length == $('input', this).length) {


### PR DESCRIPTION
### What
On CMD filter options list pages an invalid aria attribute `aria-contols` (note the missing `r`) was added. Given that this has not been found or come up in auditing I think we can safely remove it.

### How to review
1. Visit a CMD filter options list page
1. See there is an invalid `aria-contols` attribute added to one of the element. (AXE)
1. Switch to this branch
1. See that it is removed.

### Who can review
Anyone but me
