### PR TITLE
Fix - Date picker duplicate ids

### DIFF
--- a/js/app/date-picker.js
+++ b/js/app/date-picker.js
@@ -130,9 +130,9 @@ datepicker.prototype.popGrid = function() {
         if (weekday == 6 && curDay < numDays) {
             // This was the last day of the week, close it out
             // and begin a new one
-            gridCells += '\t</tr>\n\t<tr id="' + this.id + '-row' + rowCount + '">\n';
             rowCount++;
             weekday = 0;
+            gridCells += '\t</tr>\n\t<tr id="' + this.id + '-row' + rowCount + '">\n';
         }
         else {
             weekday++;


### PR DESCRIPTION
### What
The date picker has duplicate ids as it incremented the row count after creating the next rows
Found with AXE

### How to review
1. Visit a search page with a date picker
1. See that there are duplicate ids in the datepicker
1. Switch to this branch
1. See that it is resolved

### Who can review
Anyone but me
