### PR TITLE
Fix - A to Z - Disable colour contrast

### DIFF
--- a/scss/components/_filters.scss
+++ b/scss/components/_filters.scss
@@ -186,7 +186,7 @@
             &--disabled:focus {
                 cursor: not-allowed;
                 background: $disabled;
-                color: $nevada;
+                color: $abbey;
             }
         }
 


### PR DESCRIPTION
### What
The A to Z disabled items colour contrast is not enough for A or AA. Found using WAVE

### How to review
1. Visit the a to z
1. See the disabled items have insufficient contrast
1. Switch to this branch
1. See that it is now resolved

### Who can review

Anyone but me
