### PR TITLE
Fix - letter spacing

### DIFF
--- a/scss/components/_header.scss
+++ b/scss/components/_header.scss
@@ -21,6 +21,7 @@
 
         @include breakpoint(sm) {
             padding: $baseline 0;
+            display: block;
         }
 
         padding: 0; // fix for IE8
@@ -31,9 +32,11 @@
         padding: 0;
         cursor: pointer;
         display: inline-block;
+        position: relative;
 
         @include breakpoint(sm) {
             height: $baseline * 6;
+            display: block;
         }
 
         @include breakpoint(md) {
@@ -54,7 +57,7 @@
             }
 
             @include breakpoint(lg) {
-                top: 62px;  //2px less to cover borders on parent
+                top: 100%;
             }
         }
 
@@ -91,6 +94,7 @@
     &__link {
         color: $iron-light;
         text-decoration: none;
+        height: 100%;
 
         @include breakpoint(sm) {
             height: ($baseline * 6);
@@ -106,7 +110,6 @@
 
         @include breakpoint(lg) {
             font-size: 14px;
-            height: 100%;
         }
 
         //set focus styling - has to be on link to work (hover styling on li)

--- a/scss/components/_header.scss
+++ b/scss/components/_header.scss
@@ -49,16 +49,12 @@
         //children show on hover
         &:hover > ul,
         &--focus > ul {
+            top: 100%;
             @include breakpoint(md) {
                 background-color: $thunder;
                 color: $white;
                 text-decoration: none;
                 display: block;
-                top: 86px; //2px less to cover borders on parent
-            }
-
-            @include breakpoint(lg) {
-                top: 100%;
             }
         }
 
@@ -125,15 +121,12 @@
 
         //show sub-menu on keyboard focus of link
         &:focus + ul {
+            top: 100%;
+
             @include breakpoint(md) {
                 background-color: $thunder;
                 text-decoration: none;
                 display: block;
-                top: 86px; //2px less to cover same colour border on parent <li>
-            }
-
-            @include breakpoint(lg) {
-                top: 62px;
             }
         }
 

--- a/scss/components/_header.scss
+++ b/scss/components/_header.scss
@@ -273,6 +273,8 @@
     list-style: none;
     margin: 0;
     padding: 0;
+    display: flex;
+    align-items: stretch;
 
     @include breakpoint(md) {
         display: none;
@@ -281,13 +283,15 @@
     &__item {
         padding: 0;
         margin: 0;
+        display: inline-block;
+        width: 50%;
     }
 
     &__menu {
         background-color: $ship-grey;
         font-size: 17px;
         float: left;
-        width: 50%;
+        width: 100%;
         //padding-left: $col;
         padding: $baseline*2 $col;
         color: $iron-light;
@@ -302,7 +306,7 @@
         background-color: $ship-grey;
         font-size: 17px;
         float: left;
-        width: 50%;
+        width: 100%;
         //padding-left: $col;
         padding: $baseline*2 $col;
         color: $iron-light;

--- a/scss/components/_header.scss
+++ b/scss/components/_header.scss
@@ -20,7 +20,7 @@
         align-items: stretch;
 
         @include breakpoint(sm) {
-            padding: $baseline 0;
+            padding: 0 0 $baseline 0;
             display: block;
         }
 
@@ -37,6 +37,7 @@
         @include breakpoint(sm) {
             height: $baseline * 6;
             display: block;
+            padding-left: 16px;
         }
 
         @include breakpoint(md) {
@@ -201,6 +202,7 @@
         color: $iron-light;
         overflow: hidden;
         margin: 0;
+        padding-left: 32px;
     }
 }
 

--- a/scss/components/_header.scss
+++ b/scss/components/_header.scss
@@ -100,7 +100,7 @@
 
         @include breakpoint(md) {
             display: inline-block;
-            padding: 5px $baseline*2 3px $baseline*2;
+            padding: 5px $baseline*2 9px $baseline*2;
             border-left: 1px solid $thunder;
             font-size: 13px; // smaller font on medium for retina screens
         }

--- a/scss/components/_header.scss
+++ b/scss/components/_header.scss
@@ -10,16 +10,14 @@
     @include breakpoint(md) {
         border-top: 1px solid $thunder;
         border-bottom: 1px solid $thunder;
-        height: 88px;
-    }
-
-    @include breakpoint(lg) {
-        height: 64px;
     }
 
     &__list {
         list-style: none;
-        margin: 0;
+        margin: 0 auto;
+        font-size: 0;
+        display: flex;
+        align-items: stretch;
 
         @include breakpoint(sm) {
             padding: $baseline 0;
@@ -32,22 +30,16 @@
         margin: 0;
         padding: 0;
         cursor: pointer;
+        display: inline-block;
 
         @include breakpoint(sm) {
             height: $baseline * 6;
         }
 
         @include breakpoint(md) {
-            float: left;
-            height: 86px;
-
             &:nth-child(6) a {
                 border-right: 1px solid $thunder;
             }
-        }
-
-        @include breakpoint(lg) {
-            height: 62px;
         }
 
         //children show on hover
@@ -109,13 +101,12 @@
             display: inline-block;
             padding: 5px $baseline*2 3px $baseline*2;
             border-left: 1px solid $thunder;
-            height: 86px;
             font-size: 13px; // smaller font on medium for retina screens
         }
 
         @include breakpoint(lg) {
-            height: 62px;
             font-size: 14px;
+            height: 100%;
         }
 
         //set focus styling - has to be on link to work (hover styling on li)
@@ -333,14 +324,12 @@
     @include breakpoint(sm) {
         display: none;
     }
-    display: block;
 }
 
 .nav-search--hidden {
     @include breakpoint(sm) {
         display: none;
     }
-    display: block;
 }
 
 // HEADER - LOGO, LANGUAGE SELECTION AND SECONDARY NAV LINKS

--- a/scss/utilities/_utilities.scss
+++ b/scss/utilities/_utilities.scss
@@ -221,8 +221,20 @@
 .flex {
     display: flex !important;
 
-    &.stretch {
+    &.align-items-stretch {
         align-items: stretch !important;
+    }
+
+    &.flex-wrap-wrap {
+        flex-wrap: wrap !important;
+    }
+
+    .flex-basis {
+        @include breakpoint(sm) {
+            &-sm--full {
+                flex-basis: 100% !important;
+            }
+        }
     }
 }
 

--- a/scss/utilities/_utilities.scss
+++ b/scss/utilities/_utilities.scss
@@ -229,6 +229,20 @@
         flex-wrap: wrap !important;
     }
 
+    &.content {
+        &-space-between {
+            justify-content: space-between;
+        }
+
+        @include breakpoint(lg) {
+            &-lg--flex-start {
+                justify-content: flex-start;
+            }
+        }
+    }
+
+
+
     .flex-basis {
         @include breakpoint(sm) {
             &-sm--full {

--- a/scss/utilities/_utilities.scss
+++ b/scss/utilities/_utilities.scss
@@ -110,6 +110,10 @@
         }
     }
 
+    &--0 {
+        margin: 0 !important;
+    }
+
 }
 
 
@@ -184,7 +188,11 @@
 		  	padding-left: 0 !important;
 		  	padding-right: 0 !important;
 		}
-	}
+    }
+
+    &--0 {
+        padding: 0 !important;
+    }
 
 }
 
@@ -207,6 +215,14 @@
         &--md {
             display: inline-block !important;
         }
+    }
+}
+
+.flex {
+    display: flex !important;
+
+    &.stretch {
+        align-items: stretch !important;
     }
 }
 

--- a/scss/v2/components/_promo.scss
+++ b/scss/v2/components/_promo.scss
@@ -1,10 +1,15 @@
 .promo {
     &__container {
         display: block;
+        height: 100%;
 
         @include breakpoint(sm) {
             margin-left: -16px;
             margin-right: -16px;
+        }
+
+        > section {
+            height: 100%;
         }
 
         &:focus {

--- a/scss/v2/components/tile.scss
+++ b/scss/v2/components/tile.scss
@@ -19,13 +19,6 @@
         line-height: 1.5;
     }
 
-    &--employment-figures-stacked {
-        // Fixed height on md to ensure employment figures tile is flush with population tile
-        @include breakpoint(md) {
-            height: 776px;
-        }
-    }
-
     &__content-container {
         &--space-between {
             display: flex;
@@ -37,16 +30,11 @@
     }
 
     &__highlighted-content {
-        height: 340px;
-
         @include breakpoint(xs) {
-            height: auto;
             min-height: 340px;
         }
 
-        @include breakpoint(md) {
-            height: 446px;
-        }
+        height: 100%;
     }
 
     &__split-bar {


### PR DESCRIPTION
### What
Completely rework the homepage styling to remove fixed heights so that when the letter spacing is changed the content expands and the content is not obscured.

Also add some necessary flex utilities.

One known issue is that there is some unintended spacing on the tablet (breakpoint md) when the text spacing is there. This seems unavoidable without JS which seems unnecessary. This has been signed off by @armstrongb  

This works on all supported browsers.

### How to review
1. Visit any page
1. Run the letter spacing bookmarklet
1. See that content is obscured or the design is broken
1. Switch to this branch, dp-frontend-renderer branch  `fix/letter-spacing-homepage` and babbage branch `fix/letter-spacing`

### Who can review
Anyone but me
