### PR TITLE
Fix - Remove unnecessary outline offset

### DIFF
--- a/scss/v2/components/tile.scss
+++ b/scss/v2/components/tile.scss
@@ -10,7 +10,6 @@
 
     &:focus {
         outline: 2px solid $sun-yellow;
-        outline-offset: 2px;
         box-shadow: none;
     }
 


### PR DESCRIPTION
### What
Fix the homepage outline offset for the tiles when they get focus

### How to review
1. Visit the homepage
1. Focus the in focus tabs with renderer branch `fix/letter-spacing-homepage`
1. See there is an outline but it is not bordering the tiles

### Who can review
Anyone but me
