### PR TITLE
center beta badge

### DIFF
--- a/scss/components/_banner.scss
+++ b/scss/components/_banner.scss
@@ -48,7 +48,9 @@
             display: block;
             float: left;
             margin-right: 8px;
-            transform: translateY(50%);
+            transform: translateY(5%);
+            margin-bottom: 10px;
+            margin-top: 8px;
         }
     }
 


### PR DESCRIPTION
### What

Centred beta badge so that it is no longer overflowing when in landscape view on small mobile devices. 

### How to review

Go here: http://localhost:20000/datasets/cpih01/editions/time-series/versions and see that when in mobile landscape view for Pixel 2, iPhone 6/7/8 and iPhone 6/7/8 plus. The beta banner will overflow.

Pull branch and see that beta badge no longer overflows. 

### Who can review

Anyone but me. 