### PR TITLE
Feedback form focus and alert focus adjustments

### DIFF
--- a/scss/components/_form.scss
+++ b/scss/components/_form.scss
@@ -13,22 +13,20 @@
         padding: 5px 4px 4px;
         border: 2px solid #0b0c0c;
         margin-bottom: 40px;
-        outline-color: $carrot;
 
         &__inline{
             width: 70%;
         }
 
         &__error {
-            -webkit-box-shadow: 0 0 0 2px $poppy;
-            -moz-box-shadow: 0 0 0 2px $poppy;
-            box-shadow: 0 0 0 2px $poppy;
+            outline: 3px solid $poppy;
+            outline-offset: -2px;
         }
-
     }
 
     &-control:focus{
-        @include box-shadow(0 0 0 3px $carrot);
+        outline: 3px solid $carrot;
+        outline-offset: -2px;
     }
 
     &-hint{
@@ -40,7 +38,7 @@
 
     &-helper{
         color: #6f777b;
-        font-size: 14;
+        font-size: 18px;
     }
 
     &-error{

--- a/scss/components/_improve-this-page.scss
+++ b/scss/components/_improve-this-page.scss
@@ -31,7 +31,6 @@
             padding: 5px 4px 4px;
             border: 2px solid #0b0c0c;
             margin-bottom: 40px;
-            outline-color: $carrot;
 
             @media (min-width: 641px) {
                 width: 70%;
@@ -40,15 +39,14 @@
             }
 
             &__error {
-                -webkit-box-shadow: 0 0 0 2px $poppy;
-                -moz-box-shadow: 0 0 0 2px $poppy;
-                box-shadow: 0 0 0 2px $poppy;
+                outline: 3px solid $poppy;
+                outline-offset: -2px;
             }
-
         }
 
         .form-control:focus{
-            @include box-shadow(0 0 0 3px $carrot);
+            outline: 3px solid $carrot;
+            outline-offset: -2px;
         }
 
         textarea{


### PR DESCRIPTION
### What

Feedback page focus sections adjusted to fit in with the website theme
- Used to be black with orange now just orange
- Likewise alert state is now just red not orange and red
- Box-shadow was being used when it should have just been an outline
- Outline colour was specified but never given a thickness
- Error in form-helper SCSS (unit lacking px)

### How to review

Check the feedback page `/feedback?service=cmd`
Check alerts
Check focus states
Check the JS feedback form if enabled (might need to force the feedback var to true on the page model to test)

### Who can review

Anyone except me