### PR TITLE
Fix catch local dev in extractDomainFromUrl

### DIFF
--- a/js/app/cookies-banner.js
+++ b/js/app/cookies-banner.js
@@ -41,7 +41,7 @@ function submitCookieForm(e) {
 }
 
 function extractDomainFromUrl(url) {
-    if (url.indexOf('localhost') >= 0) {
+    if (url.indexOf('localhost') >= 0 || url.indexOf('127.0.0.1') >= 0) {
         return 'localhost';
     }
 


### PR DESCRIPTION
### What

Fix catch local dev (127.0.0.1) in extractDomainFromUrl

### How to review

Run homepage locally on http://127.0.0.1:20000/ and check there's no longer errors thrown by `extractDomainFromUrl()`

### Who can review

Anyone
