### PR TITLE
More accessibility work for feedback form

### DIFF
--- a/js/app/improve-this-page.js
+++ b/js/app/improve-this-page.js
@@ -1,4 +1,4 @@
-$(document).ready(function() {
+$(document).ready(function () {
     var pageURL = window.location.href;
     var feedbackOrigin = window.feedbackOrigin;
     var feedbackURL = "/feedback";
@@ -11,77 +11,89 @@ $(document).ready(function() {
         '<span id="feedback-form-confirmation" class="font-size--16">Thank you. Your feedback will help us as we continue to improve the service.</span>'
     )
 
-    $( "#feedback-form-url" ).val(pageURL);
+    $("#feedback-form-url").val(pageURL);
 
-    $( "a.js-toggle" ).click(function(e) {
+    $("a.js-toggle").click(function (e) {
         e.preventDefault();
 
         var id = $(this).attr('id');
-        $( "#feedback-form" ).toggleClass("js-hidden");
-        $( "#feedback-form-header" ).toggleClass("js-hidden");
+        $("#feedback-form").toggleClass("js-hidden");
+        $("#feedback-form-header").toggleClass("js-hidden");
 
         if (id !== "feedback-form-close") {
             $(" #description-field ").focus();
         }
     });
 
-    $( "#feedback-form-yes" ).click(function(e) {
+    $("#feedback-form-yes").click(function (e) {
         e.preventDefault();
 
         $.ajax({
             type: "POST",
             url: feedbackURL + "/positive",
             data: $("#feedback-form-container").serialize(),
-            beforeSend: function() {
-                $( "#feedback-form-header" ).html(feedbackMessage);
+            beforeSend: function () {
+                $("#feedback-form-header").html(feedbackMessage);
             }
         })
     });
 
-    $( "#feedback-form-container" ).on("submit", function(e) {
+    $("#feedback-form-container").on("submit", function (e) {
         e.preventDefault();
-        $(" #description-field ").removeClass("form-control__error");
+        var emailField = $(" #email-field ")
+        var descriptionField = $(" #description-field ")
+        descriptionField.removeClass("form-control__error");
         $(" #purpose-field ").removeClass("form-control__error");
-        $(" #email-field ").removeClass("form-control__error");
-        $(" .form-error ").each(function() {
+        emailField.removeClass("form-control__error");
+        $(" .form-error ").each(function () {
             $(this).remove();
         })
 
         var hasErrors = false;
 
-        if ($(" #description-field ").val() === "") {
+        if (descriptionField.val() === "") {
             var descriptionError = "<span class=\"form-error\" role=\"alert\">Write some feedback</span>";
             if (!$(" #description-field-label .form-error").length) {
-                $(" #description-field-label ").append( descriptionError );
-                $(" #description-field ").addClass("form-control__error");
+                $(" #description-field-label ").append(descriptionError);
+                descriptionField.addClass("form-control__error");
             }
             hasErrors = true
         }
 
-        var email = $(" #email-field ").val();
-        if (email != "") {
-            var emailError = "<span class=\"form-error\" role=\"alert\">This is not a valid email address, correct it or delete it</span>";
+        var email = emailField.val();
+        if (email !== "") {
+            var emailError;
+            // If this is not the first alert then don't announce it (otherwise screen readers will battle between the two alerts)
+            if (hasErrors) {
+                emailError = "<span class=\"form-error\" role=\"alert\" aria-live=\"polite\">This is not a valid email address, correct it or delete it</span>";
+            } else {
+                emailError = "<span class=\"form-error\" role=\"alert\">This is not a valid email address, correct it or delete it</span>";
+            }
+
             var emailReg = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,6}$/g;
 
-            if ( !emailReg.test(email) ) {
+            if (!emailReg.test(email)) {
                 if (!$(" #email-field-label .form-error").length) {
-                    $(" #email-field-label ").append( emailError );
-                    $(" #email-field ").addClass("form-control__error");
+                    $(" #email-field-label ").append(emailError);
+                    emailField.addClass("form-control__error");
                 }
                 hasErrors = true
             }
         }
 
-        if (hasErrors) { return };
+        if (hasErrors) {
+            return
+        }
 
         $.ajax({
             type: "POST",
             url: feedbackURL,
             data: $("#feedback-form-container").serialize(),
-            beforeSend: function() {
-                $( "#feedback-form" ).addClass("js-hidden");
-                $( "#feedback-form-header" ).removeClass("js-hidden");
-                $( "#feedback-form-header" ).html(feedbackMessage);
+            beforeSend: function () {
+                var formHeader = $("#feedback-form-header")
+                $("#feedback-form").addClass("js-hidden");
+                formHeader.removeClass("js-hidden");
+                formHeader.html(feedbackMessage);
             }
         })
 
@@ -93,9 +105,9 @@ $(document).ready(function() {
             if (len > 50) {
                 displayURL = "..." + displayURL.slice(len - 50, len);
             }
-            $("#feedback-description").html("<div class=\"font-size--16\"><br>Your feedback will help us to improve the website. We are unable to respond to all enquiries. If your matter is urgent, please <a href=\"/aboutus/contactus\">contact us</a>.<br><br>Return to <a class=\"underline-link\" href=\""+document.referrer+"\">"+displayURL+"</a></div>")
+            $("#feedback-description").html("<div class=\"font-size--16\"><br>Your feedback will help us to improve the website. We are unable to respond to all enquiries. If your matter is urgent, please <a href=\"/aboutus/contactus\">contact us</a>.<br><br>Return to <a class=\"underline-link\" href=\"" + document.referrer + "\">" + displayURL + "</a></div>")
         }
     });
 
-    
+
 });

--- a/js/app/improve-this-page.js
+++ b/js/app/improve-this-page.js
@@ -50,7 +50,7 @@ $(document).ready(function() {
         var hasErrors = false;
 
         if ($(" #description-field ").val() === "") {
-            var descriptionError = "<span class=\"form-error\">Write some feedback</span>";
+            var descriptionError = "<span class=\"form-error\" role=\"alert\">Write some feedback</span>";
             if (!$(" #description-field-label .form-error").length) {
                 $(" #description-field-label ").append( descriptionError );
                 $(" #description-field ").addClass("form-control__error");
@@ -58,18 +58,9 @@ $(document).ready(function() {
             hasErrors = true
         }
 
-        if ($(" #purpose-field ").val() === "") {
-            var descriptionError = "<span class=\"form-error\">Enter a purpose</span>";
-            if (!$(" #purpose-field-label .form-error").length) {
-                $(" #purpose-field-label ").append( descriptionError );
-                $(" #purpose-field ").addClass("form-control__error");
-            }
-            hasErrors = true
-        }
-
         var email = $(" #email-field ").val();
         if (email != "") {
-            var emailError = "<span class=\"form-error\">This is not a valid email address, correct it or delete it</span>";
+            var emailError = "<span class=\"form-error\" role=\"alert\">This is not a valid email address, correct it or delete it</span>";
             var emailReg = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,6}$/g;
 
             if ( !emailReg.test(email) ) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -129,9 +129,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "14.14.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.0.tgz",
-            "integrity": "sha512-BfbIHP9IapdupGhq/hc+jT5dyiBVZ2DdeC5WwJWQWDb0GijQlzUFAeIQn/2GtvZcd2HVUU7An8felIICFTC2qg==",
+            "version": "14.14.2",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.2.tgz",
+            "integrity": "sha512-jeYJU2kl7hL9U5xuI/BhKPZ4vqGM/OmK6whiFAXVhlstzZhVamWhDSmHyGLIp+RVyuF9/d0dqr2P85aFj4BvJg==",
             "dev": true
         },
         "@types/normalize-package-data": {
@@ -3584,9 +3584,9 @@
             }
         },
         "onchange": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/onchange/-/onchange-7.0.2.tgz",
-            "integrity": "sha512-pyJroR9gZKilbJtdGsuyxhFhwaeYSpYVle9hAORGJ5vQQH8n7QT+qWpncJTMEk9dlIXI9tOMjdJwbPaTSPTKFA==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/onchange/-/onchange-7.1.0.tgz",
+            "integrity": "sha512-ZJcqsPiWUAUpvmnJri5TPBooqJOPmC0ttN65juhN15Q8xA+Nbg3BaxBHXQ45EistKKlKElb0edmbPWnKSBkvMg==",
             "dev": true,
             "requires": {
                 "@blakeembrey/deque": "^1.0.5",

--- a/scss/components/_form.scss
+++ b/scss/components/_form.scss
@@ -21,12 +21,14 @@
         &__error {
             outline: 3px solid $poppy;
             outline-offset: -2px;
+            border: none;
         }
     }
 
     &-control:focus{
         outline: 3px solid $carrot;
         outline-offset: -2px;
+        border: none;
     }
 
     &-hint{

--- a/scss/components/_improve-this-page.scss
+++ b/scss/components/_improve-this-page.scss
@@ -41,12 +41,14 @@
             &__error {
                 outline: 3px solid $poppy;
                 outline-offset: -2px;
+                border: none;
             }
         }
 
         .form-control:focus{
             outline: 3px solid $carrot;
             outline-offset: -2px;
+            border: none;
         }
 
         textarea{


### PR DESCRIPTION
### What

#### Further accessibility work

- Purpose is no longer used so removed the JS from it
- Form wasn't reading out form warnings, as this is now required on other areas of the website this has now been implemented here too
- IE10  doesn't support outline-offset and so was still showing double border on focus. It no longer does.


Note: There was an issue with voiceover fighting for some users: introduced aria-live 'polite' for such situations.

### How to review

feedback?service=cmd
Check that the form works on multiple browsers, ensure voiceover NVDA etc announce alerts (submit the form with no feedback or badly formed email address)

### Who can review

Anyone except me