### PR TITLE
removed postForm code and call so as not to inundate API with PATCH calls

### DIFF
--- a/js/app/filter-select.js
+++ b/js/app/filter-select.js
@@ -65,9 +65,6 @@ $(function() {
       removeFilter(el);
     }
 
-    // Run the postForm function with the appropriate url
-      postForm(urlToPost);
-
     // Checkboxes need to return true to select/deselect
     if(!el.is(checkBox)) {
       return false;
@@ -142,17 +139,4 @@ $(function() {
     var countChildren = filterSelectList.children().length;
     $('span', filterHeader).text(countChildren);
   }
-
-  // Ajax Post the form in the background to update job with status
-  function postForm(urlToPost){
-    $.ajax({
-       type: "POST",
-       url: urlToPost,
-       data: $("#filter-form").serialize(),
-       error: function(){
-         console.log('Post error');
-       }
-     });
-   }
-
- });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -4956,9 +4956,9 @@
             "dev": true
         },
         "uglify-js": {
-            "version": "3.11.3",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.11.3.tgz",
-            "integrity": "sha512-wDRziHG94mNj2n3R864CvYw/+pc9y/RNImiTyrrf8BzgWn75JgFSwYvXrtZQMnMnOp/4UTrf3iCSQxSStPiByA=="
+            "version": "3.12.1",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.1.tgz",
+            "integrity": "sha512-o8lHP20KjIiQe5b/67Rh68xEGRrc2SRsCuuoYclXXoC74AfSRGblU1HKzJWH3HxPZ+Ort85fWHpSX7KwBUC9CQ=="
         },
         "unbzip2-stream": {
             "version": "1.4.3",


### PR DESCRIPTION
### What

Currently when on a hierarchy dimension select page in the filter journey, each click of a checkbox/add/remove link posts the form to the API. Since we are in the progress of moving from POST to PATCH calls, these individual posts are unnecessary. This PR removes the JS that is making those calls upon each checkbox toggle. Save and Return will now be the only way to post the form.

### How to review

Ensure changes make sense

### Who can review

Anyone
