### PR TITLE
clean up package-lock and revert filter-select

### DIFF
--- a/js/app/filter-select.js
+++ b/js/app/filter-select.js
@@ -65,6 +65,9 @@ $(function() {
       removeFilter(el);
     }
 
+    // Run the postForm function with the appropriate url
+      postForm(urlToPost);
+
     // Checkboxes need to return true to select/deselect
     if(!el.is(checkBox)) {
       return false;
@@ -139,4 +142,17 @@ $(function() {
     var countChildren = filterSelectList.children().length;
     $('span', filterHeader).text(countChildren);
   }
-});
+
+  // Ajax Post the form in the background to update job with status
+  function postForm(urlToPost){
+    $.ajax({
+       type: "POST",
+       url: urlToPost,
+       data: $("#filter-form").serialize(),
+       error: function(){
+         console.log('Post error');
+       }
+     });
+   }
+
+ });

--- a/package-lock.json
+++ b/package-lock.json
@@ -4956,15 +4956,9 @@
             "dev": true
         },
         "uglify-js": {
-<<<<<<< HEAD
             "version": "3.12.1",
             "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.1.tgz",
             "integrity": "sha512-o8lHP20KjIiQe5b/67Rh68xEGRrc2SRsCuuoYclXXoC74AfSRGblU1HKzJWH3HxPZ+Ort85fWHpSX7KwBUC9CQ=="
-=======
-            "version": "3.11.5",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.11.5.tgz",
-            "integrity": "sha512-btvv/baMqe7HxP7zJSF7Uc16h1mSfuuSplT0/qdjxseesDU+yYzH33eHBH+eMdeRXwujXspaCTooWHQVVBh09w=="
->>>>>>> develop
         },
         "unbzip2-stream": {
             "version": "1.4.3",


### PR DESCRIPTION
### What

Reverting the JS that made a call to filter-options for time being as this logic currently allows hte basket to properly update when navigating through various hierarchies. Maybe a long term solution will be to use session/local storage, but for now, it feels best to revert to keep that functionality working

Package-lock had leftovers from a merge conflict that have been tidied up in this PR too

### How to review

Sense check

### Who can review

Anyone
