### PR TITLE
Fix/remove all posturl

### DIFF
--- a/js/app/filter-select.js
+++ b/js/app/filter-select.js
@@ -26,7 +26,7 @@ $(function() {
 
   $(document).on('click', '.js-filter', function() {
     el = $(this);
-    urlToPost = $('#filter-form').attr('action')
+    urlToPost = $('#filter-form').attr('action');
     removeAll = $('.remove-all');
     removeOne = $('.remove-link');
 
@@ -67,13 +67,13 @@ $(function() {
     }
 
     // Run the postForm function with the appropriate url
-    postForm(urlToPost)
+    postForm(urlToPost);
 
     // Checkboxes need to return true to select/deselect
     if(!el.is(checkBox)) {
       return false;
     }
-  })
+  });
 
   // Add the selected item/s to the filter selection block (cart)
   function addToFilter(el) {

--- a/js/app/filter-select.js
+++ b/js/app/filter-select.js
@@ -21,11 +21,12 @@ $(function() {
       el, id, label, filterSelectItem, removeOne, removeAll, removeAllLink;
 
   // url
-  var urlToPost = $('#filter-form').attr('action'),
-      url = window.location.pathname;
+  var url = window.location.pathname;
+  var urlToPost;
 
-  $(document).on('click', '.js-filter', function(){
+  $(document).on('click', '.js-filter', function() {
     el = $(this);
+    urlToPost = $('#filter-form').attr('action')
     removeAll = $('.remove-all');
     removeOne = $('.remove-link');
 
@@ -66,14 +67,13 @@ $(function() {
     }
 
     // Run the postForm function with the appropriate url
-      postForm(urlToPost);
+    postForm(urlToPost)
 
     // Checkboxes need to return true to select/deselect
     if(!el.is(checkBox)) {
       return false;
     }
-
-  });
+  })
 
   // Add the selected item/s to the filter selection block (cart)
   function addToFilter(el) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2649,9 +2649,9 @@
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "ini": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
             "dev": true,
             "optional": true
         },


### PR DESCRIPTION
### What

A bug was identified where the PATCH call URL used when interacting with checkboxes in the CMD filter journey would be incorrect after the user clicked "Remove All" from the basket.

Instead of making the correct call from a checkbox interaction, it would instead make a call to `/filter/{filter_id}/dimension/{dimension_name}/update/remove-all` in perpetuity. This means any subsequent interactions the user makes were not being saved. If they were to refresh the page or go back to another level on a hierarchy filter, they would not see their changes persisted.

This PR fixes this issue which was caused by the JS implementation in Sixteens for the `filter-select` functionality by ensuring that the correct URL is set _after_ the user triggers the event listener callback.

This PR also fixes some vulnerabilities (via `npm audit fix`)

### How to review

- Go to a CMD page and click onto a given dimension in the filter journey that has checkboxes (CPIH dataset's Aggregate dimension, for instance). 
- Open up network tab. Tick some checkboxes, then click the **basket's** "Remove All" link; see that the request URLs are correct
- Having clicked "Remove All", tick some more checkboxes and see that every request URL is now to `/remove-all`.
- Repeat this journey with the changes in this branch running and see that this is no longer the case

### Who can review

Anyone but me
