### PR TITLE
Removed redundant code

### DIFF
--- a/js/app/improve-this-page.js
+++ b/js/app/improve-this-page.js
@@ -37,13 +37,12 @@ $(document).ready(function () {
             }
         })
     });
-
+    
     $("#feedback-form-container").on("submit", function (e) {
         e.preventDefault();
         var emailField = $(" #email-field ")
         var descriptionField = $(" #description-field ")
         descriptionField.removeClass("form-control__error");
-        $(" #purpose-field ").removeClass("form-control__error");
         emailField.removeClass("form-control__error");
         $(" .form-error ").each(function () {
             $(this).remove();
@@ -100,17 +99,6 @@ $(document).ready(function () {
                 $("#feedback-form-header").html(feedbackMessage);
             }
         })
-
-        if (window.location.pathname === feedbackURL) {
-            $(this).remove();
-            $("h1").html("Thank you");
-            var displayURL = document.referrer;
-            var len = displayURL.length;
-            if (len > 50) {
-                displayURL = "..." + displayURL.slice(len - 50, len);
-            }
-            $("#feedback-description").html("<div class=\"font-size--16\"><br>Your feedback will help us to improve the website. We are unable to respond to all enquiries. If your matter is urgent, please <a href=\"/aboutus/contactus\">contact us</a>.<br><br>Return to <a class=\"underline-link\" href=\"" + document.referrer + "\">" + displayURL + "</a></div>")
-        }
     });
 
 


### PR DESCRIPTION
### What

The feedback form has been failing and the JS to be deleted was masking the failed submit as it did not have sufficient error handling. The JS hooks have been removed from `dp-frontend-renderer`. This review is to delete the redundant code.

### How to review

Pull this branch and goto `/feedback` and check the feedback form still submits and handles field validation errors. Check the feedback form on the footer still works (can be found on the homepage).

### Who can review

Anyone but me
