### PR TITLE
Fix to alignment issue in mobile view

### DIFF
--- a/scss/components/_header.scss
+++ b/scss/components/_header.scss
@@ -32,7 +32,6 @@
         padding: 0;
         cursor: pointer;
         display: inline-block;
-        position: relative;
 
         @include breakpoint(sm) {
             height: $baseline * 6;


### PR DESCRIPTION
### What

Removed `relative` from element position

### How to review

1. Pull local branch
2. Run local web stack
3. Go to homepage
4. Resize screen so mobile view is shown on the nav banner OR use Chrome/Mozilla dev tools and toggle to mobile view
5. Click on `Menu -> Business, Industry and Trade -> Business` you should be able to navigate to the page (this may 404 depending on your setup)
6. Compare with the live site

### Who can review

Anyone but me
