### PR TITLE
add highlight colour for search results

### DIFF
--- a/scss/utilities/_colours.scss
+++ b/scss/utilities/_colours.scss
@@ -19,6 +19,7 @@ $mine-shaft:		#222222;
 $cod-gray:	    	#111111;
 
 //Colours:
+$neon-yellow:       #F0F762; //highlighting
 $matisse: 			#206095; //links
 $blumine:       	#1A4C76; //hover links
 $salem:				#0F8243; //active links

--- a/scss/utilities/_utilities.scss
+++ b/scss/utilities/_utilities.scss
@@ -1,6 +1,12 @@
 //_utilities.scss
 
 
+// Highlighting elasticsearch results
+.highlight {
+    background-color: $neon-yellow;
+    font-style: normal;
+    padding: 0 2px;
+}
 
 //hiding
 
@@ -677,3 +683,4 @@
 .clearfix {
     @extend %clearfix;
 }
+


### PR DESCRIPTION
### What

Add new class for elasticsearch results

### How to review

See that `.highlight` matches the ONS design system: (https://ons-design-system.netlify.app/patterns/see-important-information/)

### Who can review

Anyone but me
