### PR TITLE
Fix sixteens deploy

### DIFF
--- a/ci/scripts/build.sh
+++ b/ci/scripts/build.sh
@@ -2,6 +2,8 @@
 
 pushd sixteens
   npm install --unsafe-perm
+  SHORT_REF=`git rev-parse --short HEAD`
 popd
 
-cp -r sixteens/dist/* build/
+mkdir -p build/$SHORT_REF
+cp -r sixteens/dist/* build/$SHORT_REF


### PR DESCRIPTION
### What

The sixteens deploy at the moment is publishing to `/sixteens` on the CDN
rather than `/sixteens/{git_short_ref}`. This change ensures that this
extra segment is added to the path when uploading.

### Who can review

Anyone but me.
