### PR TITLE
fix/highcharts invisible

### DIFF
--- a/scss/utilities/_utilities.scss
+++ b/scss/utilities/_utilities.scss
@@ -400,15 +400,10 @@
 
 // Set anything with aria-hidden attributes to correct display state
  @media only screen {
-    // hotjar and highcharts css classes to be excluded
-     [aria-hidden*=true]:not([class^="_hj"] > *):not([class^="highcharts"]) {
+    // hotjar and svgs to be excluded
+     [aria-hidden*=true]:not([class^="_hj"] > *):not(svg[aria-hidden*=true]) {
          display: none;
          visibility: hidden;
-     }
-
-     svg[aria-hidden*=true] { // Allow SVGs to still show even with aria:hidden. Only want them hidden from screen readers.
-         display: block;
-         visibility: visible;
      }
 
      [aria-hidden*=false] {

--- a/scss/utilities/_utilities.scss
+++ b/scss/utilities/_utilities.scss
@@ -400,8 +400,8 @@
 
 // Set anything with aria-hidden attributes to correct display state
  @media only screen {
-    // hotjar css classes to be excluded
-     [aria-hidden*=true]:not([class^="_hj"] > *) {
+    // hotjar and highcharts css classes to be excluded
+     [aria-hidden*=true]:not([class^="_hj"] > *):not([class^="highcharts"]) {
          display: none;
          visibility: hidden;
      }


### PR DESCRIPTION
### What

Add highcharts to excluded list 
**_TL;DR_**
Adding the `:not` selector increased the css selector specificity so the selector below this one (`svg[aria-hidden*=true]`) was no longer overriding `[aria-hidden*=true]` in true CSS style. So adding a specific rule (in the PR) means that `svg[aria-hidden*=true]` is being honoured once again and the previous selector is no longer needed 😅 

### How to review

Sense check

### Who can review

!me
