### PR TITLE
Feature/preview site tile

### DIFF
--- a/scss/v2/components/tile.scss
+++ b/scss/v2/components/tile.scss
@@ -230,4 +230,57 @@
             line-height: 1.5;
         }
     }
+
+    &--swoosh {
+        display: flex; 
+        background: rgba(0, 60, 87, 0.95);
+        position: relative;
+
+        @include breakpoint(sm) {
+            margin-inline: -16px;
+            float: none;
+            width: auto;
+        }
+    }
+    
+    &--swoosh::after {
+        content: "";
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: #003C57;
+        clip-path: circle(clamp(150%, 166%, 180%) at -24% -47%);
+
+        @include breakpoint(md) {
+            clip-path: circle(838px at -11.5% -145%);
+        }
+
+        @include breakpoint(lg) {
+            clip-path: circle(838px at -33% -180%);
+        }
+    }
+
+    // for the dots SVG inside tile
+    &__dots {
+        position: absolute;
+        right: 0;
+        width: 17%;  
+        z-index: 10;
+
+        @include breakpoint(sm) {
+            height: 65%;
+            width: auto;
+            aspect-ratio: 1 / 2;
+        }
+
+        @include breakpoint(md) {
+            width: 13%;
+        }
+
+        @include breakpoint(lg) {
+            width: 17%;
+        }
+    }
 }

--- a/scss/v2/components/tile.scss
+++ b/scss/v2/components/tile.scss
@@ -29,6 +29,11 @@
         }
     }
 
+    &__content-wrapper {
+        position: relative;
+        z-index: 1;
+    }
+
     &__highlighted-content {
         @include breakpoint(xs) {
             min-height: 340px;


### PR DESCRIPTION
### What

[This](https://jira.ons.gov.uk/browse/DIS-2362) adds styling for the new preview site tile.
Figma designs can be found [here](https://www.figma.com/design/fv92Hik8lv8IvN7aPoUfr4/Homepage-sign-posting?node-id=2732-1476&m=dev)

### How to review

- Run `rm -r node_modules && npm install`
- Run `npm run dev`
- You'll also need [this branch](https://github.com/ONSdigital/dp-frontend-homepage-controller/pull/242) of the homepage controller.
   - Run homepage controller with `make debug ENABLE_PREVIEW_SITE_TILE=true`
- Goto http://localhost:24400/

**Desktop**
![image](https://github.com/user-attachments/assets/0c24da12-b959-4274-a4b5-6a08624cedd4)

**Tablet**
![image](https://github.com/user-attachments/assets/95fda10c-23ee-4347-b7e7-e6f2cf376fac)

**Mobile**
![image](https://github.com/user-attachments/assets/790d5cc4-e4b4-43b0-90cc-958656a69a7e)

Check out the preview site tile works and at different screen sizes.
Sense check

### Who can review

Frontend
