### PR TITLE
Feature/update cookie banner

### DIFF
--- a/js/app/cookies-banner.js
+++ b/js/app/cookies-banner.js
@@ -1,18 +1,19 @@
 // cookies settings
-var cookiesSet = hasCookiesPreferencesSet();
-var cookiesBanner = $(".js-cookies-banner-form");
+const cookiesSet = hasCookiesPreferencesSet();
+const cookiesBanner = $(".js-cookies-banner-form");
 
-var oneYearInSeconds = 31622400;
-var url = window.location.hostname;
-var cookiesDomain = extractDomainFromUrl(url);
-var cookiesPreference = true;
-var encodedCookiesPolicy = "%7B%22essential%22%3Atrue%2C%22usage%22%3Atrue%7D";
-var cookiesPath = "/";
+const oneYearInSeconds = 31622400;
+const url = window.location.hostname;
+const cookiesDomain = extractDomainFromUrl(url);
+const cookiesPreference = true;
+const encodedCookiesPolicy = "%7B%22essential%22%3Atrue%2C%22usage%22%3Atrue%7D";
+const defaultCookiesPolicy = "%7B%22essential%22%3Atrue%2C";
+const cookiesPath = "/";
 
 document.addEventListener("DOMContentLoaded", determineWhetherToRenderBanner());
 
 function determineWhetherToRenderBanner() {
-    var cookiesAreNotSet = !cookiesSet || userIsOnCookiesPreferencesPage()
+    const cookiesAreNotSet = !cookiesSet || userIsOnCookiesPreferencesPage()
     if (cookiesAreNotSet) {
         cookiesBanner.removeClass("cookies-banner--hidden")
         initCookiesBanner();
@@ -25,19 +26,6 @@ function initCookiesBanner() {
     });
     cookiesBanner.on('submit', submitCookieForm);
 }
-
-let $cookieButton = null;
-
-const $acceptButton = $('.js-accept-cookies');
-const $rejectButton = $('.js-reject-cookies');
-
-$acceptButton.on('click', function() {
-    $cookieButton = $(this);
-});
-
-$rejectButton.on('click', function() {
-    $cookieButton = $(this);
-});
 
 function submitCookieForm(e) {
     e.preventDefault();
@@ -72,12 +60,12 @@ function extractDomainFromUrl(url) {
     }
 
     // top level domains (TLD/SLD) in use
-    var tlds = new RegExp('(.co.uk|.onsdigital.uk|.gov.uk)');
+    const tlds = new RegExp("(\\.co\\.uk|\\.onsdigital\\.uk|\\.gov\\.uk)");
 
-    var topLevelDomain = url.match(tlds)[0];
-    var secondLevelDomain = url.replace(topLevelDomain, '').split('.').pop();
+    const topLevelDomain = url.match(tlds)[0];
+    const secondLevelDomain = url.replace(topLevelDomain, '').split('.').pop();
 
-    return "." + secondLevelDomain + topLevelDomain;
+    return `.${secondLevelDomain}${topLevelDomain}`;
 }
 
 function hasCookiesPreferencesSet() {
@@ -85,9 +73,9 @@ function hasCookiesPreferencesSet() {
 }
 
 function userIsOnCookiesPreferencesPage() {
-    var href = window.location.href.split("/");
+    const href = window.location.href.split("/");
 
     // check that last element in href array is 'cookies' - in case we add further pages within the cookies path
-    var isCookiesPreferencesPage = href[href.length - 1] === "cookies";
+    const isCookiesPreferencesPage = href[href.length - 1] === "cookies";
     return isCookiesPreferencesPage;
 }

--- a/js/app/cookies-banner.js
+++ b/js/app/cookies-banner.js
@@ -26,15 +26,41 @@ function initCookiesBanner() {
     cookiesBanner.on('submit', submitCookieForm);
 }
 
+let $cookieButton = null;
+
+const $acceptButton = $('.js-accept-cookies');
+const $rejectButton = $('.js-reject-cookies');
+
+$acceptButton.on('click', function() {
+    $cookieButton = $(this);
+});
+
+$rejectButton.on('click', function() {
+    $cookieButton = $(this);
+});
+
 function submitCookieForm(e) {
     e.preventDefault();
-    var cookiesAcceptBanner = $('.js-accept-cookies');
+    
+    const $acceptButton = $('.js-accept-cookies');
+    const $rejectButton = $('.js-reject-cookies');
+    const action = document.activeElement.getAttribute('data-action');
 
-    cookiesAcceptBanner.prop('disabled');
-    cookiesAcceptBanner.addClass("btn--primary-disabled");
+    if ($acceptButton || $rejectButton) {
+        $acceptButton.prop('disabled');
+        $acceptButton.addClass("btn--primary-disabled");
+        $rejectButton.prop('disabled');
+        $rejectButton.addClass("btn--primary-disabled");
+    }
 
-    document.cookie = "cookies_preferences_set=" + cookiesPreference + ";" + "max-age=" + oneYearInSeconds + ";" + "domain=" + cookiesDomain + ";" + "path=" + cookiesPath + ";";
-    document.cookie = "cookies_policy=" + encodedCookiesPolicy + ";" + "max-age=" + oneYearInSeconds + ";" + "domain=" + cookiesDomain + ";" + "path=" + cookiesPath + ";";
+    document.cookie = `cookies_preferences_set=${cookiesPreference};max-age=${oneYearInSeconds};domain=${cookiesDomain};path=${cookiesPath}`;
+    if (action === 'accept') {
+        document.cookie = `cookies_policy=${encodedCookiesPolicy};max-age=${oneYearInSeconds};domain=${cookiesDomain};path=${cookiesPath}`;
+        $('.ons-js-accepted-text').removeClass('hidden');
+    } else if (action === 'reject') {
+        document.cookie = `cookies_policy=${defaultCookiesPolicy};max-age=${oneYearInSeconds};domain=${cookiesDomain};path=${cookiesPath}`;
+        $('.ons-js-rejected-text').removeClass('hidden');
+    }
 
     $('.js-cookies-banner-inform').addClass('hidden');
     $('.js-cookies-banner-confirmation').removeClass('hidden');

--- a/js/app/cookies-banner.js
+++ b/js/app/cookies-banner.js
@@ -7,7 +7,7 @@ const url = window.location.hostname;
 const cookiesDomain = extractDomainFromUrl(url);
 const cookiesPreference = true;
 const encodedCookiesPolicy = "%7B%22essential%22%3Atrue%2C%22usage%22%3Atrue%7D";
-const defaultCookiesPolicy = "%7B%22essential%22%3Atrue%2C";
+const defaultCookiesPolicy = "%7B%22essential%22%3Atrue%2C%22usage%22%3Afalse%7D";
 const cookiesPath = "/";
 
 document.addEventListener("DOMContentLoaded", determineWhetherToRenderBanner());
@@ -42,12 +42,17 @@ function submitCookieForm(e) {
     }
 
     document.cookie = `cookies_preferences_set=${cookiesPreference};max-age=${oneYearInSeconds};domain=${cookiesDomain};path=${cookiesPath}`;
-    if (action === 'accept') {
-        document.cookie = `cookies_policy=${encodedCookiesPolicy};max-age=${oneYearInSeconds};domain=${cookiesDomain};path=${cookiesPath}`;
-        $('.ons-js-accepted-text').removeClass('hidden');
-    } else if (action === 'reject') {
-        document.cookie = `cookies_policy=${defaultCookiesPolicy};max-age=${oneYearInSeconds};domain=${cookiesDomain};path=${cookiesPath}`;
-        $('.ons-js-rejected-text').removeClass('hidden');
+    switch(action) {
+        case 'accept':
+            document.cookie = `cookies_policy=${encodedCookiesPolicy};max-age=${oneYearInSeconds};domain=${cookiesDomain};path=${cookiesPath}`;
+            $('.ons-js-accepted-text').removeClass('hidden');
+            break;
+        case 'reject':
+            document.cookie = `cookies_policy=${defaultCookiesPolicy};max-age=${oneYearInSeconds};domain=${cookiesDomain};path=${cookiesPath}`;
+            $('.ons-js-rejected-text').removeClass('hidden');
+            break;   
+        default:
+            return;                 
     }
 
     $('.js-cookies-banner-inform').addClass('hidden');

--- a/scss/components/_cookies-banner.scss
+++ b/scss/components/_cookies-banner.scss
@@ -74,7 +74,9 @@
     }
 
     a {
-        text-decoration: none;
+        text-decoration: underline;
+        text-underline-position: under;
+        font-size: 18px;
     }
 
     p {

--- a/scss/components/_cookies-banner.scss
+++ b/scss/components/_cookies-banner.scss
@@ -1,6 +1,6 @@
 .cookies-banner {
     background-color: $mercury;
-    padding: 20px 0;
+    padding-bottom: 10px;
     box-sizing: border-box;
 
     @include breakpoint(md-max) {
@@ -18,6 +18,8 @@
 
     &__heading {
         font-weight: 800;
+        font-size: 1.625rem;
+        line-height: 36px;
     }
 
     &__body {

--- a/scss/components/_cookies-banner.scss
+++ b/scss/components/_cookies-banner.scss
@@ -42,7 +42,7 @@
 
     &__button {
         display: inline-block;
-        margin-right: 8px;
+        padding-right: 1rem;
 
         @include breakpoint(md-max) {
             margin-top: 8px;

--- a/scss/components/_cookies-banner.scss
+++ b/scss/components/_cookies-banner.scss
@@ -1,6 +1,6 @@
 .cookies-banner {
     background-color: $mercury;
-    padding-bottom: 10px;
+    padding: 20px 0;
     box-sizing: border-box;
 
     @include breakpoint(md-max) {

--- a/scss/components/_cookies-banner.scss
+++ b/scss/components/_cookies-banner.scss
@@ -82,6 +82,8 @@
     p {
         padding: 0;
         margin: 8px 0;
+        color: #222;
+        word-break: break-word;
     }
 
     &__preferences-success {


### PR DESCRIPTION
### What

[Text](https://jira.ons.gov.uk/browse/DIS-2943) update to cookie banner

- Modified banner style
- Add reject buttons with event listener

### How to review

- Fetch local `dp-renderer` from [PR](https://github.com/ONSdigital/dp-renderer/pull/179) branch
- Changes should be as stated on [Ticket](https://jira.ons.gov.uk/browse/DIS-2943)
  - Accepting or rejecting cookies should display the acceptance or rejection banner
  - Only `Manage settings` should be visible if JS is off
- Check cookies are set if rejected or accepted
  - `cookies_preferences_set` is always set when a button is clicked
  - `essential` and `usage` cookies are set if accepted
  - Only `essential` cookie is set if rejected

![Screenshot 2025-04-22 at 15 54 36](https://github.com/user-attachments/assets/22903add-ecd0-4aa5-8a36-631023279f0a)

![image](https://github.com/user-attachments/assets/f5c81be8-164b-49d4-8ca4-89b4c3171d20)


![image](https://github.com/user-attachments/assets/c894556f-c29e-4424-b334-d4ee6158affd)

![image](https://github.com/user-attachments/assets/426d5ac8-402b-4e6e-aab0-667a31678199)

### Who can review

Anyone
