### PR TITLE
Fix/hide banner on help page

### DIFF
--- a/js/app/cookies-banner.js
+++ b/js/app/cookies-banner.js
@@ -104,9 +104,9 @@ function hasCookiesPreferencesSet() {
 
 // userIsOnCookiesPreferencesPage() check if user in in cookie page
 function userIsOnCookiesPreferencesPage() {
-  const href = window.location.href.split("/");
+  const path = window.location.pathname;
 
-  // check that last element in href array is 'cookies' - in case we add further pages within the cookies path
-  const isCookiesPreferencesPage = href[href.length - 1] === "cookies";
+  // suppress the cookies banner on the cookies preferences page
+  const isCookiesPreferencesPage = path === '/cookies';
   return isCookiesPreferencesPage;
 }


### PR DESCRIPTION
### What

Changed the `userIsOnCookiesPreferencesPage` to perform an explicit check to see if it's on the cookie preference page only and hide the banner if so.

### How to review

Sense check

### Who can review

!me
