### PR TITLE
Feature/meganav a11y improvements

### DIFF
--- a/js/app/nav.js
+++ b/js/app/nav.js
@@ -80,7 +80,7 @@ function cloneSecondaryNav() {
 
     if ($('body').hasClass('viewport-sm') && $('.js-nav-clone__list').find($navLink).length > 0) {
         // Remove from separate UL and add into primary
-        $navLink.each(function() {
+        $navLink.each(function () {
             $(this).parent().hide();
             $(this)
                 .removeClass('secondary-nav__link')
@@ -91,13 +91,13 @@ function cloneSecondaryNav() {
         });
     } else if (!$('body').hasClass('viewport-sm') && $('.secondary-nav__item').is(':hidden')) {
         // Remove from primary nav and add into separate secondary list
-        $navLink.each(function(i) {
+        $navLink.each(function (i) {
             var index = i + 1;
-           $(this)
-               .unwrap()
-               .removeClass('primary-nav__link col')
-               .addClass('secondary-nav__link')
-               .appendTo('.js-nav-clone__list li:nth-child(' + index + ')');
+            $(this)
+                .unwrap()
+                .removeClass('primary-nav__link col')
+                .addClass('secondary-nav__link')
+                .appendTo('.js-nav-clone__list li:nth-child(' + index + ')');
             $(this).parent().show();
         });
     }
@@ -126,7 +126,7 @@ function clonePrimaryItems() {
 }
 
 
-$(window).resize(function() {
+$(window).resize(function () {
     clonePrimaryItems();
     cloneSecondaryNav();
 });
@@ -141,6 +141,22 @@ $(document).ready(function () {
     clonePrimaryItems();
     cloneSecondaryNav();
 
+    $(document).on('keydown', (e) => {
+        if (e.key === 'Escape') {
+            $('.primary-nav__item:hover > ul').each(function () {
+                var $submenu = $(this);
+                $submenu.addClass('hide');
+                var $parentItem = $submenu.closest('.primary-nav__item');
+                // Restore submenu when mouse leaves the parent item
+                var handleMouseLeave = function () {
+                    $submenu.removeClass('hide');
+                    $parentItem.off('mouseleave', handleMouseLeave);
+                };
+                $parentItem.on('mouseleave', handleMouseLeave);
+            });
+        }
+    });
+
     $primaryNav.addClass('nav-main--hidden').attr('aria-expanded', false);
     //$searchBar.addClass('nav-search--hidden').attr('aria-expanded', false);
 
@@ -150,7 +166,7 @@ $(document).ready(function () {
             toggleSubnav($(this));
         }
     });
-    
+
     $expandableItem.doubleTapToGo();
 
     // stop parent element from taking over all click events
@@ -159,7 +175,7 @@ $(document).ready(function () {
     });
 
     // Menu navigation using keyboard
-    $navItem.on('keydown', function(e) {
+    $navItem.on('keydown', function (e) {
         var $this = $(this),
             $focusedItem = $('.js-expandable__child a:focus'), // only selects child item that is in focus
             keycode = e.keyCode,
@@ -176,8 +192,8 @@ $(document).ready(function () {
         if (keycode == esc) {
             $this.removeClass('primary-nav__item--focus');
             $this.closest('.js-nav').find('a:first').addClass('hide-children').focus();
-            $this.closest('.js-nav').find('a:first').focusout(function() {
-               $(this).removeClass('hide-children');
+            $this.closest('.js-nav').find('a:first').focusout(function () {
+                $(this).removeClass('hide-children');
             });
         }
         if (keycode == down) {
@@ -211,7 +227,7 @@ $(document).ready(function () {
     });
 
     // Remove focus and styling classes if mouse hovers over nav
-    $navItem.hover(function() {
+    $navItem.hover(function () {
         if ($navItem.find(':focus')) {
             $navItem.find(':focus').blur();
             $navItem.removeClass('primary-nav__item--focus');
@@ -222,7 +238,7 @@ $(document).ready(function () {
             $(this).find('.js-expandable__content').attr('aria-expanded', 'true');
         }
 
-    }, function() {
+    }, function () {
         if (!$('body').hasClass('viewport-sm')) {
             $(this).find('.primary-nav__link').attr('aria-expanded', 'false');
             $(this).find('.js-expandable__content').attr('aria-expanded', 'false');
@@ -236,7 +252,7 @@ $(document).ready(function () {
             $(this).find('.js-expandable__content').attr('aria-expanded', 'true');
         }
     });
-    $expandableItem.focusout(function ()  {
+    $expandableItem.focusout(function () {
         if (!$('body').hasClass('viewport-sm')) {
             $(this).find('.primary-nav__link').attr('aria-expanded', 'false');
             $(this).find('.js-expandable__content').attr('aria-expanded', 'false');
@@ -244,7 +260,7 @@ $(document).ready(function () {
     });
 
     // Close menu on click of the page
-    $('body').not('js-expandable .js-expandable__child').click(function() {
+    $('body').not('js-expandable .js-expandable__child').click(function () {
         $('.primary-nav__item--focus').removeClass('primary-nav__item--focus');
     });
 

--- a/scss/components/_search-bar.scss
+++ b/scss/components/_search-bar.scss
@@ -41,7 +41,7 @@
 
     @if $old-ie == false {
       @include breakpoint(sm) {
-        padding: ($baseline * 3) 0;
+        padding: ($baseline * 2) 0 ($baseline * 3);
         overflow: hidden;
       }
     }
@@ -59,7 +59,7 @@
 
     @if $old-ie == false {
       @include breakpoint(sm) {
-        display: none;
+        padding: 0 $col 12px 0;
       }
     }
   }


### PR DESCRIPTION
### What

[Meganav a11y improvements (epic)](https://officefornationalstatistics.atlassian.net/browse/DIS-4050)
✅ [Fix hidden input field on search](https://officefornationalstatistics.atlassian.net/browse/DIS-4058)
✅ [Fix inappropriate location for aria-expanded](https://officefornationalstatistics.atlassian.net/browse/DIS-4059)
✅ [Allow dismissing of nav on hover](https://officefornationalstatistics.atlassian.net/browse/DIS-4060)

### How to review

Sense check 
Seek a demo or apply changes yourself to an app

This is a library so involves various dependencies to realistically demonstrate the fixes (the easiest and quickest way is to ask me to demo...). However, to simulate locally you need to:
- Pull the [branch](https://github.com/ONSdigital/dis-design-system-go/tree/feature/4050-meganav-a11y-improvements) with changes in `dis-design-system-go` 
- Find your favourite frontend app (I used `dp-frontend-homepage-controller`)
- Likely need to port forward to sandbox api router (web); depending on the favourite frontend app you use
- Within your favourite frontend app, in `go.mod` you need to replace `dis-design-system-go` with your local instance
  - e.g. `replace "github.com/ONSdigital/dis-design-system-go" => "../dis-design-system-go"`
  - start the app e.g. `make debug`
- Generate the static assets (js/css) with `npm run dev` from within `sixteens`
- Navigate to a page that uses `sixteens` and `dis-design-system-go` for its assets ie. NOT a babbage page

1. To see the previous hidden label - resize the browser to mobile view, click search, you should now see the label
2. To test the inappropriate use of `aria-expanded` requires automated tests. I use `axe DevTools` as an extension in Chrome. Run a 'full scan' there should be no errors or 2 less than compared with sandbox/prod.
3. To test the dismissible nav bar. Make sure you're in desktop view. Use your mouse/pointer to hover over a nav element. This should display the nav elements dropdown (as existing). Press the `esc` key; the nav should disappear. Moving off and back onto the nav should display the nav again. 

<img width="417" height="351" alt="search label visible in mobile view" src="https://github.com/user-attachments/assets/c84b0dfb-7c86-4b6e-8847-9dcc1cbb561c" />

### Who can review

Frontend dev
